### PR TITLE
Renaming from Nordigen to GoCardless

### DIFF
--- a/BankoApi/.envTemplate
+++ b/BankoApi/.envTemplate
@@ -1,5 +1,5 @@
 DB_USER=<db username>
 DB_PASS=<db password>
 GOOGLE_CLOUD_IP=<0.0.0.0>
-NORDIGEN_ID=<Nordigen secret ID for token>
-NORDIGEN_KEY=<Nordigen secret key for token>
+GOCARDLESS_ID=<GoCardless secret ID for token>
+GOCARDLESS_ID_KEY=<GoCardless secret key for token>

--- a/BankoApi/Controllers/GoCardless/InstitutionsController.cs
+++ b/BankoApi/Controllers/GoCardless/InstitutionsController.cs
@@ -2,25 +2,25 @@
 using BankoApi.Services;
 using Microsoft.AspNetCore.Mvc;
 
-namespace BankoApi.Controllers.Nordigen;
+namespace BankoApi.Controllers.GoCardless;
 
 [ApiController]
 [Route("[controller]")]
 public class InstitutionsController : ControllerBase
 {
-    private readonly NordigenService _nordigenService;
+    private readonly GoCardlessService _goCardlessService;
     private readonly BankoDbContext _dbContext;
 
-    public InstitutionsController(NordigenService nordigenService, BankoDbContext dbContext)
+    public InstitutionsController(GoCardlessService goCardlessService, BankoDbContext dbContext)
     {
-        _nordigenService = nordigenService;
+        _goCardlessService = goCardlessService;
         _dbContext = dbContext;
     }
 
     [HttpGet]
     public async Task<IActionResult> GetInstitutionsAsync()
     {
-        var institutions = await _nordigenService.GetInstitutions();
+        var institutions = await _goCardlessService.GetInstitutions();
         foreach (var institution in institutions)
         {
             _dbContext.Institutions.Add(institution);    

--- a/BankoApi/Controllers/GoCardless/TransactionsController.cs
+++ b/BankoApi/Controllers/GoCardless/TransactionsController.cs
@@ -2,26 +2,26 @@ using BankoApi.Data;
 using BankoApi.Services;
 using Microsoft.AspNetCore.Mvc;
 
-namespace BankoApi.Controllers.Nordigen;
+namespace BankoApi.Controllers.GoCardless;
 
 [ApiController]
 [Route("[controller]")]
 public class TransactionsController : ControllerBase
 {
-    private readonly NordigenService _nordigenService;
+    private readonly GoCardlessService _goCardlessService;
     private readonly BankoDbContext _dbContext;
 
-    public TransactionsController(NordigenService nordigenService, BankoDbContext dbContext)
+    public TransactionsController(GoCardlessService goCardlessService, BankoDbContext dbContext)
     {
-        _nordigenService = nordigenService;
+        _goCardlessService = goCardlessService;
         _dbContext = dbContext;
     }
 
     [HttpGet("{accountId}")]
     public async Task<IActionResult> FetchAndStoreTransactions(string accountId)
     {
-        // Fetch transactions from Nordigen
-        var transactions = await _nordigenService.GetTransactionsAsync(accountId);
+        // Fetch transactions from GoCardless
+        var transactions = await _goCardlessService.GetTransactionsAsync(accountId);
         
         // Store in database
         _dbContext.Transactions.Add(transactions);

--- a/BankoApi/Migrations/20250107025814_InitialCreate.Designer.cs
+++ b/BankoApi/Migrations/20250107025814_InitialCreate.Designer.cs
@@ -25,7 +25,7 @@ namespace BankoApi.Migrations
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Balance", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Balance", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -49,7 +49,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Balances");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.BankTransactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.BankTransactions", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -64,7 +64,7 @@ namespace BankoApi.Migrations
                     b.HasAnnotation("Relational:JsonPropertyName", "transactions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Booked", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Booked", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -134,7 +134,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Booked");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.CreditorAccount", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.CreditorAccount", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -155,7 +155,7 @@ namespace BankoApi.Migrations
                     b.ToTable("CreditorAccount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.DebtorAccount", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.DebtorAccount", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -176,7 +176,7 @@ namespace BankoApi.Migrations
                     b.ToTable("DebtorAccount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Institution", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Institution", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
@@ -208,7 +208,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Institutions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Pending", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Pending", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -243,7 +243,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Pending");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Requisition", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Requisition", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
@@ -298,7 +298,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Requisitions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.TransactionAmount", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.TransactionAmount", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -319,7 +319,7 @@ namespace BankoApi.Migrations
                     b.ToTable("TransactionAmount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Transactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Transactions", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -337,21 +337,21 @@ namespace BankoApi.Migrations
                     b.ToTable("Transactions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Booked", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Booked", b =>
                 {
-                    b.HasOne("BankoApi.Data.Nordigen.BankTransactions", null)
+                    b.HasOne("BankoApi.Data.GoCardless.BankTransactions", null)
                         .WithMany("Booked")
                         .HasForeignKey("BankTransactionsId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.CreditorAccount", "CreditorAccount")
+                    b.HasOne("BankoApi.Data.GoCardless.CreditorAccount", "CreditorAccount")
                         .WithMany()
                         .HasForeignKey("CreditorAccountId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.DebtorAccount", "DebtorAccount")
+                    b.HasOne("BankoApi.Data.GoCardless.DebtorAccount", "DebtorAccount")
                         .WithMany()
                         .HasForeignKey("DebtorAccountId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.TransactionAmount", "TransactionAmount")
+                    b.HasOne("BankoApi.Data.GoCardless.TransactionAmount", "TransactionAmount")
                         .WithMany()
                         .HasForeignKey("TransactionAmountId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -364,13 +364,13 @@ namespace BankoApi.Migrations
                     b.Navigation("TransactionAmount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Pending", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Pending", b =>
                 {
-                    b.HasOne("BankoApi.Data.Nordigen.BankTransactions", null)
+                    b.HasOne("BankoApi.Data.GoCardless.BankTransactions", null)
                         .WithMany("Pending")
                         .HasForeignKey("BankTransactionsId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.TransactionAmount", "TransactionAmount")
+                    b.HasOne("BankoApi.Data.GoCardless.TransactionAmount", "TransactionAmount")
                         .WithMany()
                         .HasForeignKey("TransactionAmountId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -379,9 +379,9 @@ namespace BankoApi.Migrations
                     b.Navigation("TransactionAmount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Transactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Transactions", b =>
                 {
-                    b.HasOne("BankoApi.Data.Nordigen.BankTransactions", "BankTransactions")
+                    b.HasOne("BankoApi.Data.GoCardless.BankTransactions", "BankTransactions")
                         .WithMany()
                         .HasForeignKey("BankTransactionsId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -390,7 +390,7 @@ namespace BankoApi.Migrations
                     b.Navigation("BankTransactions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.BankTransactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.BankTransactions", b =>
                 {
                     b.Navigation("Booked");
 

--- a/BankoApi/Migrations/BankoDbContextModelSnapshot.cs
+++ b/BankoApi/Migrations/BankoDbContextModelSnapshot.cs
@@ -22,7 +22,7 @@ namespace BankoApi.Migrations
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Balance", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Balance", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -46,7 +46,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Balances");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.BankTransactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.BankTransactions", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -61,7 +61,7 @@ namespace BankoApi.Migrations
                     b.HasAnnotation("Relational:JsonPropertyName", "transactions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Booked", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Booked", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -131,7 +131,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Booked");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.CreditorAccount", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.CreditorAccount", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -152,7 +152,7 @@ namespace BankoApi.Migrations
                     b.ToTable("CreditorAccount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.DebtorAccount", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.DebtorAccount", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -173,7 +173,7 @@ namespace BankoApi.Migrations
                     b.ToTable("DebtorAccount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Institution", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Institution", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
@@ -205,7 +205,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Institutions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Pending", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Pending", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -240,7 +240,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Pending");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Requisition", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Requisition", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
@@ -295,7 +295,7 @@ namespace BankoApi.Migrations
                     b.ToTable("Requisitions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.TransactionAmount", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.TransactionAmount", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -316,7 +316,7 @@ namespace BankoApi.Migrations
                     b.ToTable("TransactionAmount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Transactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Transactions", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -334,21 +334,21 @@ namespace BankoApi.Migrations
                     b.ToTable("Transactions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Booked", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Booked", b =>
                 {
-                    b.HasOne("BankoApi.Data.Nordigen.BankTransactions", null)
+                    b.HasOne("BankoApi.Data.GoCardless.BankTransactions", null)
                         .WithMany("Booked")
                         .HasForeignKey("BankTransactionsId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.CreditorAccount", "CreditorAccount")
+                    b.HasOne("BankoApi.Data.GoCardless.CreditorAccount", "CreditorAccount")
                         .WithMany()
                         .HasForeignKey("CreditorAccountId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.DebtorAccount", "DebtorAccount")
+                    b.HasOne("BankoApi.Data.GoCardless.DebtorAccount", "DebtorAccount")
                         .WithMany()
                         .HasForeignKey("DebtorAccountId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.TransactionAmount", "TransactionAmount")
+                    b.HasOne("BankoApi.Data.GoCardless.TransactionAmount", "TransactionAmount")
                         .WithMany()
                         .HasForeignKey("TransactionAmountId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -361,13 +361,13 @@ namespace BankoApi.Migrations
                     b.Navigation("TransactionAmount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Pending", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Pending", b =>
                 {
-                    b.HasOne("BankoApi.Data.Nordigen.BankTransactions", null)
+                    b.HasOne("BankoApi.Data.GoCardless.BankTransactions", null)
                         .WithMany("Pending")
                         .HasForeignKey("BankTransactionsId");
 
-                    b.HasOne("BankoApi.Data.Nordigen.TransactionAmount", "TransactionAmount")
+                    b.HasOne("BankoApi.Data.GoCardless.TransactionAmount", "TransactionAmount")
                         .WithMany()
                         .HasForeignKey("TransactionAmountId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -376,9 +376,9 @@ namespace BankoApi.Migrations
                     b.Navigation("TransactionAmount");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.Transactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.Transactions", b =>
                 {
-                    b.HasOne("BankoApi.Data.Nordigen.BankTransactions", "BankTransactions")
+                    b.HasOne("BankoApi.Data.GoCardless.BankTransactions", "BankTransactions")
                         .WithMany()
                         .HasForeignKey("BankTransactionsId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -387,7 +387,7 @@ namespace BankoApi.Migrations
                     b.Navigation("BankTransactions");
                 });
 
-            modelBuilder.Entity("BankoApi.Data.Nordigen.BankTransactions", b =>
+            modelBuilder.Entity("BankoApi.Data.GoCardless.BankTransactions", b =>
                 {
                     b.Navigation("Booked");
 

--- a/BankoApi/Program.cs
+++ b/BankoApi/Program.cs
@@ -25,14 +25,14 @@ builder.Services.AddDbContext<BankoDbContext>(options =>
     options.UseSqlServer(connectionString);
 });
 
-String baseUrl = builder.Configuration["NordigenAPI:BaseUrl"] ?? throw new Exception("GoCadless Base URL is missing");
-String version = builder.Configuration["NordigenAPI:version"] ?? throw new Exception("GoCadless API version is missing");
+String baseUrl = builder.Configuration["GoCardlessAPI:BaseUrl"] ?? throw new Exception("GoCadless Base URL is missing");
+String version = builder.Configuration["GoCardlessAPI:version"] ?? throw new Exception("GoCadless API version is missing");
     
-builder.Services.AddHttpClient<NordigenTokenService>(client =>
+builder.Services.AddHttpClient<GoCardlessTokenService>(client =>
 {
     client.BaseAddress = new Uri(new Uri(baseUrl), version); ;
 });
-builder.Services.AddHttpClient<NordigenService>(client =>
+builder.Services.AddHttpClient<GoCardlessService>(client =>
 {
     client.BaseAddress = new Uri(new Uri(baseUrl),  version);
     client.DefaultRequestHeaders.Accept.Add(

--- a/BankoApi/Services/GoCardlessService.cs
+++ b/BankoApi/Services/GoCardlessService.cs
@@ -4,13 +4,13 @@ using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace BankoApi.Services;
 
-public class NordigenService
+public class GoCardlessService
 {
     private HttpClient _httpClient;
-    private NordigenTokenService _tokenService;
-    private ILogger<NordigenService> _logger;
+    private GoCardlessTokenService _tokenService;
+    private ILogger<GoCardlessService> _logger;
     
-    public NordigenService(HttpClient httpClient, NordigenTokenService tokenService, ILogger<NordigenService> logger)
+    public GoCardlessService(HttpClient httpClient, GoCardlessTokenService tokenService, ILogger<GoCardlessService> logger)
     {
         _httpClient = httpClient; 
         _tokenService = tokenService;

--- a/BankoApi/Services/GoCardlessTokenService.cs
+++ b/BankoApi/Services/GoCardlessTokenService.cs
@@ -2,16 +2,16 @@ using DotNetEnv;
 
 namespace BankoApi.Services;
 
-public class NordigenTokenService
+public class GoCardlessTokenService
 {
     private readonly HttpClient _httpClient;
     private readonly IConfiguration _configuration;
-    private readonly ILogger<NordigenTokenService> _logger;
+    private readonly ILogger<GoCardlessTokenService> _logger;
 
     private string _accessToken;
     private DateTime _tokenExpiry;
 
-    public NordigenTokenService(HttpClient httpClient, IConfiguration configuration, ILogger<NordigenTokenService> logger)
+    public GoCardlessTokenService(HttpClient httpClient, IConfiguration configuration, ILogger<GoCardlessTokenService> logger)
     {
         _httpClient = httpClient;
         _configuration = configuration;
@@ -32,13 +32,13 @@ public class NordigenTokenService
         Env.Load();
 
         // Otherwise, retrieve a new token
-        _logger.LogInformation("Retrieving new token from Nordigen.");
-        var secretId = Environment.GetEnvironmentVariable("NORDIGEN_ID") ?? "";
-        var secretKey = Environment.GetEnvironmentVariable("NORDIGEN_KEY") ?? "";
+        _logger.LogInformation("Retrieving new token from GoCardless.");
+        var secretId = Environment.GetEnvironmentVariable("GOCARDLESS_ID") ?? "";
+        var secretKey = Environment.GetEnvironmentVariable("GOCARDLESS_KEY") ?? "";
 
         if (string.IsNullOrEmpty(secretId) || string.IsNullOrEmpty(secretKey))
         {
-            throw new InvalidOperationException("Nordigen credentials are not configured.");
+            throw new InvalidOperationException("GoCardless credentials are not configured.");
         }
 
         var response = await _httpClient.PostAsJsonAsync(
@@ -51,10 +51,10 @@ public class NordigenTokenService
 
            response.EnsureSuccessStatusCode();
 
-        var tokenResponse = await response.Content.ReadFromJsonAsync<NordigenTokenResponse>();
+        var tokenResponse = await response.Content.ReadFromJsonAsync<GoCardlessTokenResponse>();
         if (tokenResponse == null || string.IsNullOrEmpty(tokenResponse.Access))
         {
-            throw new InvalidOperationException("Failed to retrieve Nordigen token.");
+            throw new InvalidOperationException("Failed to retrieve GoCardless token.");
         }
 
         _accessToken = tokenResponse.Access;
@@ -65,7 +65,7 @@ public class NordigenTokenService
     }
 }
 
-public class NordigenTokenResponse
+public class GoCardlessTokenResponse
 {
     public string Access { get; set; }
     public int Expires { get; set; } // Token expiry time in seconds

--- a/BankoApi/appsettings.json
+++ b/BankoApi/appsettings.json
@@ -5,7 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "NordigenAPI": {
+  "GoCardlessAPI": {
     "BaseUrl": "https://bankaccountdata.gocardless.com/",
     "Version": "api/v2/"
   },


### PR DESCRIPTION
## What

- Renaming all references from Nordigen to GoCardless

## Why

- Nordigen changed company name to GoCardless. Even the base url for the API has changed so it's better to rename the references to avoid misunderstandings