### PR TITLE
Enhances nullability of the ExpenseTagId

### DIFF
--- a/BankoApi/Controllers/BankoApi/Requests/UpdateExpanseTagRequest.cs
+++ b/BankoApi/Controllers/BankoApi/Requests/UpdateExpanseTagRequest.cs
@@ -2,6 +2,6 @@ namespace BankoApi.Controllers.BankoApi.Requests;
 
 public class UpdateExpenseTagRequest
 {
-    public string ExpenseTagId { get; set; }
+    public string? ExpenseTagId { get; set; }
     public string TransactionId { get; set; }
 }

--- a/BankoApi/Controllers/BankoApi/TransactionsController.cs
+++ b/BankoApi/Controllers/BankoApi/TransactionsController.cs
@@ -1,5 +1,6 @@
 using BankoApi.Controllers.BankoApi.Requests;
 using BankoApi.Data;
+using BankoApi.Data.Dao;
 using BankoApi.Services.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -76,10 +77,18 @@ public class TransactionsController : ControllerBase
     {
         var transaction = _dbContext.Transactions.Find(request.TransactionId);
         if (transaction == null) return NotFound();
-        
-        var expenseTag = _dbContext.ExpenseTag.Find(request.ExpenseTagId);
-        
-        transaction.ExpenseTag = expenseTag;
+
+        if (request.ExpenseTagId != null)
+        {
+            var expenseTag = _dbContext.ExpenseTag.Find(request.ExpenseTagId);
+            transaction.ExpenseTag = expenseTag;
+            transaction.ExpenseTagId = expenseTag?.Id;
+        }
+        else
+        {
+            transaction.ExpenseTag = null;
+            transaction.ExpenseTagId = null;
+        }
         _dbContext.Entry(transaction).State = EntityState.Modified;
         await _dbContext.SaveChangesAsync();
         

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -9,7 +9,6 @@ public class BankoDbContext : DbContext
     public BankoDbContext(DbContextOptions<BankoDbContext> options) : base(options)
     {
     }
-
     public DbSet<Institutions> Institutions { get; set; }
     public DbSet<Balance> Balances { get; set; }
     public DbSet<Requisition> Requisitions { get; set; }
@@ -36,7 +35,7 @@ public class BankoDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-
+        
         modelBuilder.Entity<Transaction>()
             .HasOne(t => t.DebtorAccount) // Explicitly set the relationship
             .WithMany() // Assuming a one-to-many relationship
@@ -52,8 +51,9 @@ public class BankoDbContext : DbContext
         modelBuilder.Entity<Transaction>()
             .HasOne(t => t.ExpenseTag) // Explicitly set the relationship
             .WithMany()
-            .HasForeignKey("ExpenseTagId") // Define the FK explicitly
-            .OnDelete(DeleteBehavior.Restrict); // Avoid cascading deletes
+            .HasForeignKey(t => t.ExpenseTagId) // Define the FK explicitly
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull); // Avoid cascading deletes
 
         modelBuilder.Entity<ExpenseTag>()
             .HasKey(et => et.Id);

--- a/BankoApi/Data/Dao/Transaction.cs
+++ b/BankoApi/Data/Dao/Transaction.cs
@@ -19,6 +19,7 @@ public class Transaction
     public CreditorAccount? CreditorAccount { get; set; }
     public string? DebtorName { get; set; }
     public List<string>? RemittanceInformationStructuredArray { get; set; }
+    public string? ExpenseTagId { get; set; }
     public ExpenseTag? ExpenseTag { get; set; }
 }
 


### PR DESCRIPTION
## What

- Allows the UpdateExpenseTags endpoint to accept a nullable ExpenseTagId.
- Changed the DB structure to accept a null and update the Transaction table accordingly.

## Why

I want to be able to remove the tag once it has been assigned