### PR TITLE
Transaction query optimization

### DIFF
--- a/BankoApi/Controllers/BankoApi/TransactionsController.cs
+++ b/BankoApi/Controllers/BankoApi/TransactionsController.cs
@@ -44,7 +44,7 @@ public class TransactionsController : ControllerBase
             .Select(t => t.Id)
             .ToListAsync();
 
-// Then load full entities with relationships
+        // Then load full entities with relationships
         var transactions = await _dbContext.Transactions
             .Where(t => transactionIds.Contains(t.Id))
             .Include(t => t.DebtorAccount)


### PR DESCRIPTION
## WHAT
- Splits the transaction query in two. The first half looks for transactions ids, the second half retrieves the data.

## WHY
- This reduce the amount of time the query takes to compute given all the joins needed for the query.