### PR TITLE
Transaction id fix

### DIFF
--- a/BankoApi/Data/Dao/Transaction.cs
+++ b/BankoApi/Data/Dao/Transaction.cs
@@ -17,7 +17,7 @@ public class Transaction
 
     public required string RemittanceInformationUnstructured { get; set; }
     public required List<string> RemittanceInformationUnstructuredArray { get; set; }
-    public required string BankTransactionCode { get; set; }
+    public string? BankTransactionCode { get; set; }
     public required string InternalTransactionId { get; set; }
     public string? CreditorName { get; set; }
     public CreditorAccount? CreditorAccount { get; set; }

--- a/BankoApi/Migrations/20250920072345_FixingTransactionID.Designer.cs
+++ b/BankoApi/Migrations/20250920072345_FixingTransactionID.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250920072345_FixingTransactionID")]
+    partial class FixingTransactionID
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20250920072345_FixingTransactionID.cs
+++ b/BankoApi/Migrations/20250920072345_FixingTransactionID.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixingTransactionID : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "BankTransactionCode",
+                table: "Transactions",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "BankTransactionCode",
+                table: "Transactions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/BankoApi/Services/Model/Transactions.cs
+++ b/BankoApi/Services/Model/Transactions.cs
@@ -22,14 +22,14 @@ public class BankTransactions
 
 public class Booked
 {
-    public required string TransactionId { get; set; }
+    public string? TransactionId { get; set; }
     public required string BookingDate { get; set; }
     public required string ValueDate { get; set; }
     public required TransactionAmount TransactionAmount { get; set; }
     public DebtorAccount? DebtorAccount { get; set; }
     public required string RemittanceInformationUnstructured { get; set; }
     public required List<string> RemittanceInformationUnstructuredArray { get; set; }
-    public required string BankTransactionCode { get; set; }
+    public string? BankTransactionCode { get; set; }
     public required string InternalTransactionId { get; set; }
     public string? CreditorName { get; set; }
     public CreditorAccount? CreditorAccount { get; set; }


### PR DESCRIPTION
## What
- Changed the TransactionID to be optional in the GoCardless API call response.
- Changed the BankTransactionCode to be optional

## Why
- The GoCardless TransactionId and the BankTransactionCode seem to be an optional field that went missing in a couple of transaction lately. Given the mandatority both in the Transaction DTO model and the DAO one, storing new transactions was failing.