### PR TITLE
Renaming from AccountId to BankAccountId

### DIFF
--- a/BankoApi/Controllers/BankoApi/Controllers/SettingsController/BankAccountController.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/SettingsController/BankAccountController.cs
@@ -60,10 +60,10 @@ namespace BankoApi.Controllers.BankoApi.Controllers.SettingsController.SettingsC
         {
             try
             {
-                var account = await _dbContext.BankAccounts.FirstOrDefaultAsync(a => a.BankAccountId == request.AccountId)
+                var account = await _dbContext.BankAccounts.FirstOrDefaultAsync(a => a.BankAccountId == request.BankAccountId)
                     ?? new BankAccount()
                     {
-                        BankAccountId = request.AccountId,
+                        BankAccountId = request.BankAccountId,
                         BankAuthorizationId = request.BankAuthorizationId
                     };
 
@@ -99,7 +99,7 @@ namespace BankoApi.Controllers.BankoApi.Controllers.SettingsController.SettingsC
                 return Ok(new UpsertBankAccountResponse()
                 {
                     BankAuthorizationId = account.BankAuthorizationId,
-                    AccountId = account.BankAccountId,
+                    BankAccountId = account.BankAccountId,
                     Iban = account.Iban,
                     Bban = account.Bban,
                     OwnerName = account.OwnerName,

--- a/BankoApi/Controllers/BankoApi/Controllers/SettingsController/Requests/UpsertBankAccountRequest.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/SettingsController/Requests/UpsertBankAccountRequest.cs
@@ -3,7 +3,7 @@
     public class UpsertBankAccountRequest
     {
         public Guid BankAuthorizationId { get; set; }
-        public String AccountId { get; set; }
+        public String BankAccountId { get; set; }
         public String? Iban { get; set; }
         public String? Bban { get; set; }
         public String? Currency { get; set; }

--- a/BankoApi/Controllers/BankoApi/Controllers/SettingsController/Responses/UpsertBankAccountResponse.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/SettingsController/Responses/UpsertBankAccountResponse.cs
@@ -6,7 +6,7 @@ namespace BankoApi.Controllers.BankoApi.Controllers.SettingsController.Responses
     public class UpsertBankAccountResponse
     {
         public Guid BankAuthorizationId { get; set; }
-        public String AccountId { get; set; }
+        public String BankAccountId { get; set; }
         public String? Iban { get; set; }
         public String? Bban { get; set; }
         public String? Currency { get; set; }


### PR DESCRIPTION
## WHAT
Renaming from AccountId to BankAccountId

## WHY
- For consistency