### PR TITLE
Debtor and Creditor Account IBAN fix

### DIFF
--- a/BankoApi/Services/Model/Transactions.cs
+++ b/BankoApi/Services/Model/Transactions.cs
@@ -46,14 +46,38 @@ public class TransactionAmount
 
 public class DebtorAccount
 {
-    public required string Iban { get; set; }
-    public required string Bban { get; set; }
+    private string _iban = "XX0000000000000";
+    private string _bban = "00000000000";
+
+    public string Iban
+    {
+        get => _iban;
+        set => _iban = value ?? "XX0000000000000";
+    }
+
+    public string Bban
+    {
+        get => _bban;
+        set => _bban = value ?? "00000000000";
+    }
 }
 
 public class CreditorAccount
 {
-    public required string Iban { get; set; }
-    public required string Bban { get; set; }
+    private string _iban = "XX0000000000000";
+    private string _bban = "00000000000";
+
+    public string Iban
+    {
+        get => _iban;
+        set => _iban = value ?? "XX0000000000000";
+    }
+
+    public string Bban
+    {
+        get => _bban;
+        set => _bban = value ?? "00000000000";
+    }
 }
 
 public class Pending

--- a/BankoApi/Services/SheduledTaskService.cs
+++ b/BankoApi/Services/SheduledTaskService.cs
@@ -25,7 +25,7 @@ public class ScheduledTaskService : BackgroundService
             if (now > nextRun)
                 nextRun = nextRun.AddDays(1); // Ensure next run is tomorrow if current time passed the scheduled time
 
-            // Wait until the next scheduled time
+            //Wait until the next scheduled time
             var delay = nextRun - now;
             await Task.Delay(delay, stoppingToken);
 


### PR DESCRIPTION
## WHAT
- Adds a default IBAN and BBAN for both Creditor and Debtor Account obect

## WHY
- Apparently they can be null on the GoCardless side and the Json serializer fails