### PR TITLE
Delete transaction endpoint

### DIFF
--- a/BankoApi/Controllers/BankoApi/Controllers/TransacrionsController/TransactionsController.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/TransacrionsController/TransactionsController.cs
@@ -38,7 +38,9 @@ public class TransactionsController : ControllerBase
 
         // First get just the IDs with pagination
         var transactionIds = await _dbContext.Transactions
-            .Where(t => t.BookingDate >= fromDate && t.BookingDate <= toDate)
+            .Where(t => t.isDeleted != true &&
+                        t.BookingDate >= fromDate && 
+                        t.BookingDate <= toDate)
             .OrderByDescending(t => t.BookingDate)
             .Skip(skip)
             .Take(pageSize)
@@ -61,6 +63,16 @@ public class TransactionsController : ControllerBase
             PageNumber = pageNumber,
             PageSize = pageSize
         });
+    }
+
+    [HttpDelete("{transactionId}")]
+    public async Task<IActionResult> DeleteTransaction([FromRoute] string transactionId)
+    {
+        var transaction = _dbContext.Transactions.Find(transactionId);
+        if (transaction == null) return NotFound();
+        transaction.isDeleted = true;
+        await _dbContext.SaveChangesAsync();
+        return Ok("Transaction updated");
     }
 
     private void ValidateTransaction(int pageNumber, int pageSize, DateTime? fromDate, DateTime? toDate)

--- a/BankoApi/Data/Dao/Transaction.cs
+++ b/BankoApi/Data/Dao/Transaction.cs
@@ -25,6 +25,7 @@ public class Transaction
     public List<string>? RemittanceInformationStructuredArray { get; set; }
     public string ExpenseTagId { get; set; }
     public string? Note { get; set; }
+    public bool isDeleted { get; set; }
     public virtual ExpenseTag? ExpenseTag { get; set; }
 }
 

--- a/BankoApi/Migrations/20260128162620_IsDeleteTransactionColumn.Designer.cs
+++ b/BankoApi/Migrations/20260128162620_IsDeleteTransactionColumn.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260128162620_IsDeleteTransactionColumn")]
+    partial class IsDeleteTransactionColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260128162620_IsDeleteTransactionColumn.cs
+++ b/BankoApi/Migrations/20260128162620_IsDeleteTransactionColumn.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class IsDeleteTransactionColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "isDeleted",
+                table: "Transactions",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "isDeleted",
+                table: "Transactions");
+        }
+    }
+}


### PR DESCRIPTION
## WHAT
- Implements a soft delete of the transactions in the database

## WHY
- The GoCardless Service is sending duplicates and they affect the monthly sum.
- The soft delete solve also the problem on how to definitely remove the transaction and not re-registering every day from the gocardless service.