### PR TITLE
Fix/async void fetch transactions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,27 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 9.0
+
+      - name: Restore Dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Run Tests
+        run: dotnet test --no-restore --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -445,3 +445,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# macOS
+.DS_Store

--- a/BankoApi.Tests/BankoApi.Tests.csproj
+++ b/BankoApi.Tests/BankoApi.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BankoApi\BankoApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/BankoApi.Tests/Controllers/BankoApiTransactionsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/BankoApiTransactionsControllerTests.cs
@@ -1,0 +1,272 @@
+using BankoApi.Controllers.BankoApi.Controllers.SettingsController.Requests;
+using BankoApi.Controllers.BankoApi.Controllers.TransacrionsController;
+using BankoApi.Controllers.BankoApi.Controllers.TransacrionsController.Requests;
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace BankoApi.Tests.Controllers;
+
+public class BankoApiTransactionsControllerTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetTransactions_NoFilters_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        SeedTransaction(ctx);
+        var controller = new TransactionsController(ctx);
+
+        var result = await controller.GetTransactions();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetTransactions_WithDateRange_ReturnsFilteredResults()
+    {
+        using var ctx = CreateContext();
+        SeedTransaction(ctx);
+        var controller = new TransactionsController(ctx);
+
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+
+        var result = await controller.GetTransactions(fromDate: fromDate, toDate: toDate);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetTransactions_InvalidPageNumber_ThrowsArgumentException()
+    {
+        using var ctx = CreateContext();
+        var controller = new TransactionsController(ctx);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            controller.GetTransactions(pageNumber: 0));
+    }
+
+    [Fact]
+    public async Task GetTransactions_InvalidPageSize_ThrowsArgumentException()
+    {
+        using var ctx = CreateContext();
+        var controller = new TransactionsController(ctx);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            controller.GetTransactions(pageSize: 0));
+    }
+
+    [Fact]
+    public async Task GetTransactions_FromDateAfterToDate_ThrowsArgumentException()
+    {
+        using var ctx = CreateContext();
+        var controller = new TransactionsController(ctx);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            controller.GetTransactions(
+                fromDate: new DateTime(2024, 12, 31),
+                toDate: new DateTime(2024, 1, 1)));
+    }
+
+    [Fact]
+    public async Task DeleteTransaction_ExistingTransaction_MarksAsDeleted()
+    {
+        using var ctx = CreateContext();
+        var tx = new Transaction
+        {
+            Id = "tx-to-delete",
+            UserId = Guid.NewGuid(),
+            BankAccountId = Guid.NewGuid(),
+            BookingDate = DateTime.UtcNow,
+            ValueDate = DateTime.UtcNow,
+            Amount = "100.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Test",
+            RemittanceInformationUnstructuredArray = new List<string> { "Test" },
+            InternalTransactionId = "internal-del"
+        };
+        ctx.Transactions.Add(tx);
+        ctx.SaveChanges();
+
+        var controller = new TransactionsController(ctx);
+        var result = await controller.DeleteTransaction("tx-to-delete");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.True(ctx.Transactions.Find("tx-to-delete")!.isDeleted);
+    }
+
+    [Fact]
+    public async Task DeleteTransaction_NonExistingTransaction_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = new TransactionsController(ctx);
+
+        var result = await controller.DeleteTransaction("non-existent");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateExpenseTags_ExistingTransaction_UpdatesExpenseTag()
+    {
+        using var ctx = CreateContext();
+        var tagId = "tag-1";
+        ctx.ExpenseTag.Add(new ExpenseTag
+        {
+            Id = tagId,
+            Name = "Test Tag",
+            Color = 123456,
+            isEarning = false
+        });
+        var tx = new Transaction
+        {
+            Id = "tx-tag-update",
+            UserId = Guid.NewGuid(),
+            BankAccountId = Guid.NewGuid(),
+            BookingDate = DateTime.UtcNow,
+            ValueDate = DateTime.UtcNow,
+            Amount = "100.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Test",
+            RemittanceInformationUnstructuredArray = new List<string> { "Test" },
+            InternalTransactionId = "internal-tag"
+        };
+        ctx.Transactions.Add(tx);
+        ctx.SaveChanges();
+
+        var controller = new TransactionsController(ctx);
+        var request = new UpdateExpenseTagRequest
+        {
+            TransactionId = "tx-tag-update",
+            ExpenseTagId = tagId
+        };
+
+        var result = await controller.UpdateExpenseTags(request);
+
+        Assert.IsType<OkObjectResult>(result);
+        var updated = ctx.Transactions.Find("tx-tag-update");
+        Assert.Equal(tagId, updated!.ExpenseTagId);
+    }
+
+    [Fact]
+    public async Task UpdateExpenseTags_NullExpenseTagId_ClearsExpenseTag()
+    {
+        using var ctx = CreateContext();
+        var tx = new Transaction
+        {
+            Id = "tx-clear-tag",
+            UserId = Guid.NewGuid(),
+            BankAccountId = Guid.NewGuid(),
+            BookingDate = DateTime.UtcNow,
+            ValueDate = DateTime.UtcNow,
+            Amount = "100.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Test",
+            RemittanceInformationUnstructuredArray = new List<string> { "Test" },
+            InternalTransactionId = "internal-clear",
+            ExpenseTagId = "old-tag"
+        };
+        ctx.Transactions.Add(tx);
+        ctx.SaveChanges();
+
+        var controller = new TransactionsController(ctx);
+        var request = new UpdateExpenseTagRequest
+        {
+            TransactionId = "tx-clear-tag",
+            ExpenseTagId = null
+        };
+
+        var result = await controller.UpdateExpenseTags(request);
+
+        Assert.IsType<OkObjectResult>(result);
+        var updated = ctx.Transactions.Find("tx-clear-tag");
+        Assert.Null(updated!.ExpenseTagId);
+    }
+
+    [Fact]
+    public async Task UpdateExpenseTags_NonExistingTransaction_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = new TransactionsController(ctx);
+        var request = new UpdateExpenseTagRequest
+        {
+            TransactionId = "non-existent",
+            ExpenseTagId = "tag-1"
+        };
+
+        var result = await controller.UpdateExpenseTags(request);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateNote_ExistingTransaction_UpdatesNote()
+    {
+        using var ctx = CreateContext();
+        var tx = new Transaction
+        {
+            Id = "tx-note",
+            UserId = Guid.NewGuid(),
+            BankAccountId = Guid.NewGuid(),
+            BookingDate = DateTime.UtcNow,
+            ValueDate = DateTime.UtcNow,
+            Amount = "100.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Test",
+            RemittanceInformationUnstructuredArray = new List<string> { "Test" },
+            InternalTransactionId = "internal-note"
+        };
+        ctx.Transactions.Add(tx);
+        ctx.SaveChanges();
+
+        var controller = new TransactionsController(ctx);
+        var request = new UpdateNoteRequest { Note = "Updated note" };
+
+        var result = await controller.UpdateNote("tx-note", request);
+
+        Assert.IsType<OkObjectResult>(result);
+        var updated = ctx.Transactions.Find("tx-note");
+        Assert.Equal("Updated note", updated!.Note);
+    }
+
+    [Fact]
+    public async Task UpdateNote_NonExistingTransaction_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = new TransactionsController(ctx);
+        var request = new UpdateNoteRequest { Note = "Note" };
+
+        var result = await controller.UpdateNote("non-existent", request);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    private void SeedTransaction(BankoDbContext ctx)
+    {
+        ctx.Transactions.Add(new Transaction
+        {
+            Id = "tx-1",
+            UserId = Guid.NewGuid(),
+            BankAccountId = Guid.NewGuid(),
+            BookingDate = new DateTime(2024, 6, 15),
+            ValueDate = new DateTime(2024, 6, 15),
+            Amount = "150.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Seed transaction",
+            RemittanceInformationUnstructuredArray = new List<string> { "Seed transaction" },
+            InternalTransactionId = "internal-seed"
+        });
+        ctx.SaveChanges();
+    }
+}

--- a/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Text.Json;
+using BankoApi.Controllers.GoCardless;
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using BankoApi.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace BankoApi.Tests.Controllers;
+
+public class GoCardlessTransactionsControllerTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    [Fact]
+    public async Task FetchAndStoreTransactions_NoUser_ReturnsWithNoUser()
+    {
+        using var ctx = CreateContext();
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = new TransactionsController(service, ctx);
+        var bankAccountId = Guid.NewGuid();
+
+        var result = await controller.FetchAndStoreTransactions(bankAccountId);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task FetchAndStoreTransactions_EmptyResponse_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        ctx.Users.Add(new User
+        {
+            UserId = Guid.NewGuid(),
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        // Return empty body which will deserialize as null Transactions
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json")
+            });
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = new TransactionsController(service, ctx);
+        var bankAccountId = Guid.NewGuid();
+
+        var result = await controller.FetchAndStoreTransactions(bankAccountId);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task FetchAndStoreTransactions_EndUserAgreementException_ReturnsUnauthorized()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        var agreementId = Guid.NewGuid().ToString();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            AgreementId = agreementId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = new StringContent($"EUA was valid for 90 days and it expired {agreementId}")
+            });
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = new TransactionsController(service, ctx);
+        var bankAccountId = Guid.NewGuid();
+
+        var result = await controller.FetchAndStoreTransactions(bankAccountId);
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task FetchAndStoreTransactions_GeneralException_ReturnsBadRequest()
+    {
+        using var ctx = CreateContext();
+        ctx.Users.Add(new User
+        {
+            UserId = Guid.NewGuid(),
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        // Return 500 to cause HttpRequestException
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = new TransactionsController(service, ctx);
+        var bankAccountId = Guid.NewGuid();
+
+        var result = await controller.FetchAndStoreTransactions(bankAccountId);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task FetchAndStoreTransactions_Success_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        ctx.Users.Add(new User
+        {
+            UserId = Guid.NewGuid(),
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var transactionsResponse = new
+        {
+            transactions = new
+            {
+                booked = Array.Empty<object>(),
+                pending = Array.Empty<object>()
+            }
+        };
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(transactionsResponse,
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = new TransactionsController(service, ctx);
+        var bankAccountId = Guid.NewGuid();
+
+        var result = await controller.FetchAndStoreTransactions(bankAccountId);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/BankoApi.Tests/Controllers/SettingsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/SettingsControllerTests.cs
@@ -1,0 +1,582 @@
+using System.Net;
+using System.Text.Json;
+using BankoApi.Controllers.BankoApi.Controllers.SettingsController.Requests;
+using BankoApi.Controllers.BankoApi.Controllers.SettingsController.Responses;
+using BankoApi.Controllers.BankoApi.Controllers.SettingsController.SettingsController;
+using BankoApi.Controllers.GoCardless.Requests;
+using BankoApi.Controllers.GoCardless.Responses;
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using BankoApi.Services;
+using BankoApi.Services.Model;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Moq.Protected;
+
+namespace BankoApi.Tests.Controllers;
+
+public class SettingsControllerTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    private SettingsController CreateController(BankoDbContext ctx, GoCardlessService? goCardlessService = null)
+    {
+        if (goCardlessService == null)
+        {
+            var handlerMock = MockHelpers.CreateHandlerWithToken();
+            goCardlessService = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        }
+        return new SettingsController(goCardlessService, ctx);
+    }
+
+    [Fact]
+    public async Task GetAllTagsAsync_HasTags_ReturnsTags()
+    {
+        using var ctx = CreateContext();
+        ctx.ExpenseTag.Add(new ExpenseTag
+        {
+            Id = "tag-1",
+            Name = "Groceries",
+            Color = 0xFF0000,
+            isEarning = false
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var result = await controller.GetAllTagsAsync();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<GetExpenseTagsResponse>(okResult.Value);
+        Assert.Single(response.ExpenseTags);
+    }
+
+    [Fact]
+    public async Task GetAllTagsAsync_NoTags_ReturnsEmptyList()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+
+        var result = await controller.GetAllTagsAsync();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<GetExpenseTagsResponse>(okResult.Value);
+        Assert.Empty(response.ExpenseTags);
+    }
+
+    [Fact]
+    public async Task AddExpenseTagAsync_ValidTag_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+        var tag = new ExpenseTag
+        {
+            Id = "new-tag",
+            Name = "New Tag",
+            Color = 0x00FF00,
+            isEarning = false
+        };
+
+        var result = await controller.AddExpenseTagAsync(tag);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Single(ctx.ExpenseTag);
+    }
+
+    [Fact]
+    public async Task UpdateExpenseTagAsync_ExistingTag_UpdatesFields()
+    {
+        using var ctx = CreateContext();
+        ctx.ExpenseTag.Add(new ExpenseTag
+        {
+            Id = "tag-update",
+            Name = "Old Name",
+            Color = 0x000000,
+            isEarning = false
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var updatedTag = new ExpenseTag
+        {
+            Id = "tag-update",
+            Name = "New Name",
+            Color = 0xFFFFFF,
+            isEarning = true,
+            Aka = new List<string> { "Alias" }
+        };
+
+        var result = await controller.UpdateExpenseTagAsync("tag-update", updatedTag);
+
+        Assert.IsType<OkObjectResult>(result);
+        var tag = ctx.ExpenseTag.Find("tag-update");
+        Assert.Equal("New Name", tag!.Name);
+        Assert.True(tag.isEarning);
+    }
+
+    [Fact]
+    public async Task UpdateExpenseTagAsync_NonExistingTag_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+        var updatedTag = new ExpenseTag
+        {
+            Id = "nonexistent",
+            Name = "Nope",
+            Color = 0,
+            isEarning = false
+        };
+
+        var result = await controller.UpdateExpenseTagAsync("nonexistent", updatedTag);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteExpenseTagAsync_ExistingTag_RemovesTag()
+    {
+        using var ctx = CreateContext();
+        ctx.ExpenseTag.Add(new ExpenseTag
+        {
+            Id = "tag-delete",
+            Name = "Delete Me",
+            Color = 0,
+            isEarning = false
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var result = await controller.DeleteExpenseTagAsync("tag-delete");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Empty(ctx.ExpenseTag);
+    }
+
+    [Fact]
+    public async Task DeleteExpenseTagAsync_NonExistingTag_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+
+        var result = await controller.DeleteExpenseTagAsync("nonexistent");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task GetBankAuthorization_ExistingUser_ReturnsAuthorizations()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var result = await controller.GetBankAuthorization(userId);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<GetBankAuthorizationsResponse>(okResult.Value);
+        Assert.Single(response.BankAuthorizations);
+    }
+
+    [Fact]
+    public async Task GetBankAuthorization_NoAuthorizations_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+
+        var result = await controller.GetBankAuthorization(Guid.NewGuid());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UpsertBankAuthorization_InvalidUser_ReturnsUnauthorized()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+        var request = new UpsertBankAuthorizationRequest
+        {
+            UserId = Guid.NewGuid(),
+            Status = BankAuthorizationStaus.Processing,
+            AgreementId = "agreement-1"
+        };
+
+        var result = await controller.UpsertBankAuthorization(request);
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task UpsertBankAuthorization_NewAuthorization_CreatesIt()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var request = new UpsertBankAuthorizationRequest
+        {
+            UserId = userId,
+            Status = BankAuthorizationStaus.Processing,
+            AgreementId = "agreement-new",
+            InstitutionId = "TEST_BANK",
+            InstitutionName = "Test Bank"
+        };
+
+        var result = await controller.UpsertBankAuthorization(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<UpsertBankAuthorizationResponse>(okResult.Value);
+        Assert.Equal("agreement-new", response.AgreementId);
+        Assert.Equal("TEST_BANK", response.InstitutionId);
+    }
+
+    [Fact]
+    public async Task UpsertBankAuthorization_ExistingAuthorization_UpdatesIt()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        var authId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = authId,
+            UserId = userId,
+            AgreementId = "agreement-existing",
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var request = new UpsertBankAuthorizationRequest
+        {
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            AgreementId = "agreement-existing",
+            RequisitionId = "req-1"
+        };
+
+        var result = await controller.UpsertBankAuthorization(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<UpsertBankAuthorizationResponse>(okResult.Value);
+        Assert.Equal(BankAuthorizationStaus.Linked, response.Status);
+        Assert.Equal("req-1", response.RequisitionId);
+    }
+
+    [Fact]
+    public async Task GetBankAccount_ValidIds_ReturnsAccounts()
+    {
+        using var ctx = CreateContext();
+        var bankAuthId = Guid.NewGuid();
+        ctx.BankAccounts.Add(new BankAccount
+        {
+            Id = Guid.NewGuid(),
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = "acc-1",
+            Iban = "GB33BUKB20201555555555",
+            Currency = "GBP",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var result = await controller.GetBankAccount(new List<string> { "acc-1" });
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<GetBankAccountsResponse>(okResult.Value);
+        Assert.Single(response.Accounts);
+    }
+
+    [Fact]
+    public async Task GetBankAccount_EmptyIds_ReturnsBadRequest()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+
+        var result = await controller.GetBankAccount(new List<string>());
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetBankAccount_NonExistingId_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+
+        var result = await controller.GetBankAccount(new List<string> { "nonexistent" });
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UpsertBankAccount_NewAccount_CreatesIt()
+    {
+        using var ctx = CreateContext();
+        var bankAuthId = Guid.NewGuid();
+        var controller = CreateController(ctx);
+        var request = new UpsertBankAccountRequest
+        {
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = "new-acc",
+            Iban = "DE89370400440532013000",
+            Currency = "EUR",
+            OwnerName = "Test Owner"
+        };
+
+        var result = await controller.UpsertBankAccount(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<UpsertBankAccountResponse>(okResult.Value);
+        Assert.Equal("new-acc", response.BankAccountId);
+        Assert.Equal("DE89370400440532013000", response.Iban);
+    }
+
+    [Fact]
+    public async Task UpsertBankAccount_ExistingAccount_UpdatesIt()
+    {
+        using var ctx = CreateContext();
+        var bankAuthId = Guid.NewGuid();
+        ctx.BankAccounts.Add(new BankAccount
+        {
+            Id = Guid.NewGuid(),
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = "existing-acc",
+            Iban = "OLDIBAN",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx);
+        var request = new UpsertBankAccountRequest
+        {
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = "existing-acc",
+            Iban = "NEWIBAN",
+            OwnerName = "New Owner"
+        };
+
+        var result = await controller.UpsertBankAccount(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<UpsertBankAccountResponse>(okResult.Value);
+        Assert.Equal("NEWIBAN", response.Iban);
+    }
+
+    [Fact]
+    public async Task UpsertEndUserAgreement_WithInstitutionId_CreatesNewEuaAndRequisition()
+    {
+        using var ctx = CreateContext();
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("agreements/enduser/") && r.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        count = 1,
+                        results = new[]
+                        {
+                            new
+                            {
+                                id = "existing-eua",
+                                created = DateTime.UtcNow.AddDays(-1),
+                                institution_id = "TEST_BANK",
+                                max_historical_days = 30,
+                                access_valid_for_days = 30,
+                                access_scope = new[] { "balances", "transactions" },
+                                accepted = DateTime.UtcNow,
+                                reconfirmation = false
+                            }
+                        }
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("agreements/enduser/") && r.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "new-eua",
+                        created = DateTime.UtcNow,
+                        institution_id = "TEST_BANK",
+                        max_historical_days = 30,
+                        access_valid_for_days = 30,
+                        access_scope = new[] { "balances", "transactions" },
+                        accepted = (DateTime?)null,
+                        reconfirmation = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("requisitions/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "new-req",
+                        created = DateTime.UtcNow,
+                        redirect = "Banko://bank-auth-callback",
+                        status = "CR",
+                        institution_id = "TEST_BANK",
+                        agreement = "new-eua",
+                        reference = "ref-123",
+                        accounts = Array.Empty<string>(),
+                        user_language = "EN",
+                        link = "https://bank.link/req",
+                        ssn = "",
+                        account_selection = false,
+                        redirect_immediate = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = new SettingsController(service, ctx);
+        var request = new UpsertEndUserAgreementRequest
+        {
+            InstitutionId = "TEST_BANK",
+            DaysOfAccess = 30
+        };
+
+        var result = await controller.UpsertEndUserAgreement(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<UpsertEndUserAgreementResponse>(okResult.Value);
+        Assert.Equal("new-eua", response.AgreementId);
+        Assert.Equal("https://bank.link/req", response.Link);
+    }
+
+    [Fact]
+    public async Task UpsertEndUserAgreement_WithValidExistingEua_UsesExisting()
+    {
+        using var ctx = CreateContext();
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("agreements/enduser/") && r.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        count = 1,
+                        results = new[]
+                        {
+                            new
+                            {
+                                id = "valid-eua",
+                                created = DateTime.UtcNow,
+                                institution_id = "TEST_BANK",
+                                max_historical_days = 30,
+                                access_valid_for_days = 30,
+                                access_scope = new[] { "balances", "transactions" },
+                                accepted = (DateTime?)null,
+                                reconfirmation = false
+                            }
+                        }
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("requisitions/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "req-1",
+                        created = DateTime.UtcNow,
+                        redirect = "Banko://bank-auth-callback",
+                        status = "CR",
+                        institution_id = "TEST_BANK",
+                        agreement = "valid-eua",
+                        reference = "ref-1",
+                        accounts = Array.Empty<string>(),
+                        user_language = "EN",
+                        link = "https://bank.link/req",
+                        ssn = "",
+                        account_selection = false,
+                        redirect_immediate = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = new SettingsController(service, ctx);
+        var request = new UpsertEndUserAgreementRequest();
+
+        var result = await controller.UpsertEndUserAgreement(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<UpsertEndUserAgreementResponse>(okResult.Value);
+        Assert.Equal("valid-eua", response.AgreementId);
+    }
+}

--- a/BankoApi.Tests/Controllers/UsersControllerTests.cs
+++ b/BankoApi.Tests/Controllers/UsersControllerTests.cs
@@ -1,0 +1,163 @@
+using BankoApi.Controllers.BankoApi.Controllers.UsersController;
+using BankoApi.Controllers.BankoApi.Controllers.UsersController.Requests;
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using Microsoft.AspNetCore.Identity.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace BankoApi.Tests.Controllers;
+
+public class UsersControllerTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    [Fact]
+    public async Task NewUser_ValidRequest_ReturnsOkWithUserId()
+    {
+        using var ctx = CreateContext();
+        var controller = new UsersController(ctx);
+
+        var request = new NewUserRequest
+        {
+            Email = "new@example.com",
+            Password = "password12345",
+            FullName = "New User",
+            ConsentGiven = true
+        };
+
+        var result = await controller.NewUser(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = okResult.Value;
+        Assert.NotNull(response);
+    }
+
+    [Fact]
+    public async Task NewUser_DuplicateEmail_ReturnsConflict()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "existing@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = new UsersController(ctx);
+        var request = new NewUserRequest
+        {
+            Email = "existing@example.com",
+            Password = "password12345"
+        };
+
+        var result = await controller.NewUser(request);
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_ValidCredentials_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        var controller = new UsersController(ctx);
+
+        // Create user first via the controller
+        var createRequest = new NewUserRequest
+        {
+            Email = "login@example.com",
+            Password = "correctpassword123"
+        };
+        await controller.NewUser(createRequest);
+
+        // Now login
+        var loginRequest = new LoginRequest
+        {
+            Email = "login@example.com",
+            Password = "correctpassword123"
+        };
+
+        var result = await controller.Login(loginRequest);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_WrongCredentials_ReturnsUnauthorized()
+    {
+        using var ctx = CreateContext();
+        var controller = new UsersController(ctx);
+
+        var createRequest = new NewUserRequest
+        {
+            Email = "login2@example.com",
+            Password = "correctpassword123"
+        };
+        await controller.NewUser(createRequest);
+
+        var loginRequest = new LoginRequest
+        {
+            Email = "login2@example.com",
+            Password = "wrongpassword"
+        };
+
+        var result = await controller.Login(loginRequest);
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_InactiveUser_ReturnsForbidden()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "inactive@example.com",
+            IsActive = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = new UsersController(ctx);
+        var loginRequest = new LoginRequest
+        {
+            Email = "inactive@example.com",
+            Password = "anypassword"
+        };
+
+        var result = await controller.Login(loginRequest);
+
+        var statusCodeResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, statusCodeResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task NewUser_MinimalData_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        var controller = new UsersController(ctx);
+
+        var request = new NewUserRequest
+        {
+            Email = "minimal@example.com",
+            Password = "minimalpassword"
+        };
+
+        var result = await controller.NewUser(request);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/BankoApi.Tests/MockHelpers.cs
+++ b/BankoApi.Tests/MockHelpers.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using System.Text.Json;
+using BankoApi.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+namespace BankoApi.Tests;
+
+public static class MockHelpers
+{
+    public static void SetGoCardlessEnvVars()
+    {
+        Environment.SetEnvironmentVariable("GOCARDLESS_ID", "test-id");
+        Environment.SetEnvironmentVariable("GOCARDLESS_KEY", "test-key");
+    }
+
+    /// <summary>
+    /// Creates an HttpMessageHandler that responds to "token/new/" with a token response
+    /// and responds to all other requests with the provided function.
+    /// </summary>
+    public static Mock<HttpMessageHandler> CreateHandlerWithToken(
+        Func<HttpRequestMessage, HttpResponseMessage>? otherRequestsHandler = null)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("token/new/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    access = "test-access-token",
+                    expires = 3600
+                }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri != null && !r.RequestUri.AbsolutePath.EndsWith("token/new/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+                otherRequestsHandler?.Invoke(request) ?? new HttpResponseMessage(HttpStatusCode.OK));
+
+        return handlerMock;
+    }
+
+    /// <summary>
+    /// Creates a real GoCardlessService that will make HTTP calls through the provided handler.
+    /// The handler should handle both token requests and API requests.
+    /// </summary>
+    public static GoCardlessService CreateGoCardlessServiceWithHandler(HttpMessageHandler handler)
+    {
+        SetGoCardlessEnvVars();
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.example.com/v1/")
+        };
+
+        var tokenHttpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.example.com/v1/")
+        };
+
+        var configMock = new Mock<IConfiguration>();
+        var tokenLoggerMock = new Mock<ILogger<GoCardlessTokenService>>();
+        var tokenService = new GoCardlessTokenService(tokenHttpClient, configMock.Object, tokenLoggerMock.Object);
+
+        var serviceLoggerMock = new Mock<ILogger<GoCardlessService>>();
+        return new GoCardlessService(httpClient, tokenService, serviceLoggerMock.Object);
+    }
+}

--- a/BankoApi.Tests/Models/DtoAndModelTests.cs
+++ b/BankoApi.Tests/Models/DtoAndModelTests.cs
@@ -1,0 +1,18 @@
+using BankoApi.Services.Model;
+
+namespace BankoApi.Tests.Models;
+
+public class DtoAndModelTests
+{
+    [Fact]
+    public void DebtorAccount_NullValuesUseDefaults()
+    {
+        var account = new BankoApi.Services.Model.DebtorAccount
+        {
+            Iban = null,
+            Bban = null
+        };
+        Assert.Equal("XX0000000000000", account.Iban);
+        Assert.Equal("00000000000", account.Bban);
+    }
+}

--- a/BankoApi.Tests/Repository/BankAuthorizationRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/BankAuthorizationRepositoryTests.cs
@@ -1,0 +1,117 @@
+using BankoApi.Repository;
+using BankoApi.Services.Model;
+
+namespace BankoApi.Tests.Repository;
+
+public class BankAuthorizationRepositoryTests
+{
+    [Fact]
+    public void HasValidNonAcceptedAgreement_NullResults_ReturnsNull()
+    {
+        var repo = new BankAuthorizationRepository();
+        var result = repo.HasValidNonAcceptedAgreement(new PaginatedEndUserAgreements());
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HasValidNonAcceptedAgreement_EmptyResults_ReturnsNull()
+    {
+        var repo = new BankAuthorizationRepository();
+        var agreements = new PaginatedEndUserAgreements
+        {
+            Results = new List<EndUserAgreement>()
+        };
+        var result = repo.HasValidNonAcceptedAgreement(agreements);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HasValidNonAcceptedAgreement_AllAccepted_ReturnsNull()
+    {
+        var repo = new BankAuthorizationRepository();
+        var agreements = new PaginatedEndUserAgreements
+        {
+            Results = new List<EndUserAgreement>
+            {
+                new()
+                {
+                    Id = "1",
+                    Created = DateTime.UtcNow.AddDays(-10),
+                    AccessValidForDays = 30,
+                    Accepted = DateTime.UtcNow.AddDays(-5)
+                }
+            }
+        };
+        var result = repo.HasValidNonAcceptedAgreement(agreements);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HasValidNonAcceptedAgreement_NonAcceptedWithSufficientTime_ReturnsAgreement()
+    {
+        var repo = new BankAuthorizationRepository();
+        var agreement = new EndUserAgreement
+        {
+            Id = "valid-id",
+            Created = DateTime.UtcNow,
+            AccessValidForDays = 30,
+            Accepted = null
+        };
+        var agreements = new PaginatedEndUserAgreements
+        {
+            Results = new List<EndUserAgreement> { agreement }
+        };
+
+        var result = repo.HasValidNonAcceptedAgreement(agreements);
+        Assert.NotNull(result);
+        Assert.Equal("valid-id", result.Id);
+    }
+
+    [Fact]
+    public void HasValidNonAcceptedAgreement_NonAcceptedExpiringSoon_ReturnsNull()
+    {
+        var repo = new BankAuthorizationRepository();
+        var agreement = new EndUserAgreement
+        {
+            Id = "expiring-id",
+            Created = DateTime.UtcNow.AddDays(-25),
+            AccessValidForDays = 30,
+            Accepted = null
+        };
+        var agreements = new PaginatedEndUserAgreements
+        {
+            Results = new List<EndUserAgreement> { agreement }
+        };
+
+        var result = repo.HasValidNonAcceptedAgreement(agreements);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HasValidNonAcceptedAgreement_MultipleNonAccepted_ReturnsNewestWithSufficientTime()
+    {
+        var repo = new BankAuthorizationRepository();
+        var oldAgreement = new EndUserAgreement
+        {
+            Id = "old-id",
+            Created = DateTime.UtcNow.AddDays(-20),
+            AccessValidForDays = 30,
+            Accepted = null
+        };
+        var newAgreement = new EndUserAgreement
+        {
+            Id = "new-id",
+            Created = DateTime.UtcNow,
+            AccessValidForDays = 30,
+            Accepted = null
+        };
+        var agreements = new PaginatedEndUserAgreements
+        {
+            Results = new List<EndUserAgreement> { oldAgreement, newAgreement }
+        };
+
+        var result = repo.HasValidNonAcceptedAgreement(agreements);
+        Assert.NotNull(result);
+        Assert.Equal("new-id", result.Id);
+    }
+}

--- a/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
@@ -1,0 +1,198 @@
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using BankoApi.Repository;
+using BankoApi.Services.Model;
+using Microsoft.EntityFrameworkCore;
+using PendingDto = BankoApi.Services.Model.Pending;
+
+namespace BankoApi.Tests.Repository;
+
+public class TransactionsRepositoryTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    private Transactions CreateSampleTransactions()
+    {
+        return new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    new()
+                    {
+                        TransactionId = "tx-1",
+                        BookingDate = "2024-01-15",
+                        ValueDate = "2024-01-15",
+                        TransactionAmount = new TransactionAmount
+                        {
+                            Amount = "100.00",
+                            Currency = "EUR"
+                        },
+                        RemittanceInformationUnstructured = "Payment 1",
+                        RemittanceInformationUnstructuredArray = new List<string> { "Payment 1" },
+                        InternalTransactionId = "internal-1",
+                        BankTransactionCode = "PMNT",
+                        CreditorName = "Creditor A",
+                        DebtorName = "Debtor A"
+                    },
+                    new()
+                    {
+                        TransactionId = "tx-2",
+                        BookingDate = "2024-01-16",
+                        ValueDate = "2024-01-16",
+                        TransactionAmount = new TransactionAmount
+                        {
+                            Amount = "200.00",
+                            Currency = "EUR"
+                        },
+                        RemittanceInformationUnstructured = "Payment 2",
+                        RemittanceInformationUnstructuredArray = new List<string> { "Payment 2" },
+                        InternalTransactionId = "internal-2",
+                        BankTransactionCode = "PMNT"
+                    }
+                },
+                Pending = new List<PendingDto>
+                {
+                    new()
+                    {
+                        BookingDate = "2024-01-17",
+                        TransactionAmount = new TransactionAmount
+                        {
+                            Amount = "50.00",
+                            Currency = "EUR"
+                        },
+                        RemittanceInformationUnstructured = "Pending payment",
+                        RemittanceInformationUnstructuredArray = new List<string> { "Pending payment" }
+                    }
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task StoreTransactions_NewTransactions_StoresAll()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = CreateSampleTransactions();
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        Assert.Equal(2, ctx.Transactions.Count());
+        Assert.Equal(1, ctx.Pendings.Count());
+    }
+
+    [Fact]
+    public async Task StoreTransactions_DuplicateInternalTransactionId_SkipsDuplicates()
+    {
+        using var ctx = CreateContext();
+        ctx.Transactions.Add(new Transaction
+        {
+            Id = "existing-tx",
+            UserId = Guid.NewGuid(),
+            BankAccountId = Guid.NewGuid(),
+            BookingDate = DateTime.UtcNow,
+            ValueDate = DateTime.UtcNow,
+            Amount = "50.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Existing",
+            RemittanceInformationUnstructuredArray = new List<string> { "Existing" },
+            InternalTransactionId = "internal-1"
+        });
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = CreateSampleTransactions();
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        // Only tx-2 should be added (tx-1 has duplicate InternalTransactionId)
+        Assert.Equal(2, ctx.Transactions.Count());
+    }
+
+    [Fact]
+    public async Task StoreTransactions_EmptyTransactionId_GeneratesNewGuid()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    new()
+                    {
+                        TransactionId = null,
+                        BookingDate = "2024-01-15",
+                        ValueDate = "2024-01-15",
+                        TransactionAmount = new TransactionAmount
+                        {
+                            Amount = "100.00",
+                            Currency = "EUR"
+                        },
+                        RemittanceInformationUnstructured = "No ID",
+                        RemittanceInformationUnstructuredArray = new List<string> { "No ID" },
+                        InternalTransactionId = "internal-new"
+                    }
+                },
+                Pending = new List<PendingDto>()
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var stored = ctx.Transactions.First();
+        Assert.NotNull(stored.Id);
+        Assert.NotEqual("", stored.Id);
+    }
+
+    [Fact]
+    public void SetEuaExpirationStatus_ValidAgreementId_UpdatesStatus()
+    {
+        using var ctx = CreateContext();
+        var agreementId = Guid.NewGuid().ToString();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            AgreementId = agreementId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var repo = new TransactionsRepository();
+        repo.SetEuaExpirationStatus(ctx, $"EUA was valid for 90 days and it expired {agreementId}");
+
+        var auth = ctx.BankAuthorizations.First();
+        Assert.Equal(BankAuthorizationStaus.Expired, auth.Status);
+    }
+
+    [Fact]
+    public void SetEuaExpirationStatus_MessageWithoutGuid_ThrowsEndUserAgreementException()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+
+        Assert.Throws<BankoApi.Exceptions.GoCardless.Transactions.EndUserAgreementException>(
+            () => repo.SetEuaExpirationStatus(ctx, "No GUID in this message"));
+    }
+}

--- a/BankoApi.Tests/Repository/UserRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/UserRepositoryTests.cs
@@ -1,0 +1,167 @@
+using BankoApi.Controllers.BankoApi.DTO;
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using BankoApi.Exceptions.User;
+using BankoApi.Repository;
+using Microsoft.EntityFrameworkCore;
+
+namespace BankoApi.Tests.Repository;
+
+public class UserRepositoryTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    [Fact]
+    public void CreateAccount_NewUser_ReturnsUserIdAndAddsUser()
+    {
+        using var ctx = CreateContext();
+        var repo = new UserRepository();
+        var dto = new UserDto
+        {
+            Email = "test@example.com",
+            Password = "password12345",
+            FullName = "Test User",
+            Address = "123 Test St",
+            PhoneNumber = "555-0000",
+            ConsentGiven = true
+        };
+
+        var userId = repo.CreateAccount(ctx, dto);
+        ctx.SaveChanges();
+
+        Assert.NotEqual(Guid.Empty, userId);
+        var user = ctx.Users.Find(userId);
+        Assert.NotNull(user);
+        Assert.Equal("test@example.com", user.Email);
+        Assert.Equal("Test User", user.FullName);
+        Assert.True(user.ConsentGiven);
+    }
+
+    [Fact]
+    public void CreateAccount_ExistingInactiveUser_Reactivates()
+    {
+        using var ctx = CreateContext();
+        var repo = new UserRepository();
+        var id = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = id,
+            Email = "existing@example.com",
+            IsActive = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var dto = new UserDto
+        {
+            Email = "existing@example.com",
+            Password = "newpassword123",
+            FullName = "Reactivated User"
+        };
+
+        var userId = repo.CreateAccount(ctx, dto);
+
+        Assert.Equal(id, userId);
+        var user = ctx.Users.Find(id);
+        Assert.True(user.IsActive);
+    }
+
+    [Fact]
+    public void CreateAccount_ExistingActiveUser_ThrowsEmailConflictException()
+    {
+        using var ctx = CreateContext();
+        var repo = new UserRepository();
+        ctx.Users.Add(new User
+        {
+            UserId = Guid.NewGuid(),
+            Email = "active@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var dto = new UserDto
+        {
+            Email = "active@example.com",
+            Password = "password12345"
+        };
+
+        Assert.Throws<EmailConflictException>(() => repo.CreateAccount(ctx, dto));
+    }
+
+    [Fact]
+    public void ValidateAccount_ValidCredentials_ReturnsUserId()
+    {
+        using var ctx = CreateContext();
+        var repo = new UserRepository();
+        var dto = new UserDto
+        {
+            Email = "valid@example.com",
+            Password = "correctpassword123",
+            ConsentGiven = true
+        };
+        var id = repo.CreateAccount(ctx, dto);
+        ctx.SaveChanges();
+
+        var userId = repo.ValidateAccount(ctx, "valid@example.com", "correctpassword123");
+
+        Assert.Equal(id, userId);
+        var user = ctx.Users.Find(id);
+        Assert.NotNull(user.LastLoginAt);
+    }
+
+    [Fact]
+    public void ValidateAccount_EmailNotFound_ThrowsEmailNotFoundException()
+    {
+        using var ctx = CreateContext();
+        var repo = new UserRepository();
+
+        Assert.Throws<EmailNotFoundException>(() =>
+            repo.ValidateAccount(ctx, "nonexistent@example.com", "password123"));
+    }
+
+    [Fact]
+    public void ValidateAccount_InactiveUser_ThrowsInactiveUserException()
+    {
+        using var ctx = CreateContext();
+        var repo = new UserRepository();
+        var id = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = id,
+            Email = "inactive@example.com",
+            IsActive = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        Assert.Throws<InactiveUserException>(() =>
+            repo.ValidateAccount(ctx, "inactive@example.com", "password123"));
+    }
+
+    [Fact]
+    public void ValidateAccount_WrongPassword_ThrowsPasswordNotFoundException()
+    {
+        using var ctx = CreateContext();
+        var repo = new UserRepository();
+        var dto = new UserDto
+        {
+            Email = "user@example.com",
+            Password = "correctpassword123"
+        };
+        repo.CreateAccount(ctx, dto);
+        ctx.SaveChanges();
+
+        Assert.Throws<PasswordNotFoundException>(() =>
+            repo.ValidateAccount(ctx, "user@example.com", "wrongpassword"));
+    }
+}

--- a/BankoApi.Tests/Services/GoCardlessServiceTests.cs
+++ b/BankoApi.Tests/Services/GoCardlessServiceTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Text.Json;
+using BankoApi.Exceptions.GoCardless.Transactions;
+using BankoApi.Services;
+using BankoApi.Services.Model;
+using Moq;
+using Moq.Protected;
+
+namespace BankoApi.Tests.Services;
+
+public class GoCardlessServiceTests
+{
+    [Fact]
+    public async Task GetTransactionsAsync_Success_ReturnsTransactions()
+    {
+        var accountId = Guid.NewGuid();
+        var transactionsResponse = new
+        {
+            transactions = new
+            {
+                booked = new[]
+                {
+                    new
+                    {
+                        transactionId = "tx-1",
+                        bookingDate = "2024-01-15",
+                        valueDate = "2024-01-15",
+                        transactionAmount = new { amount = "100.00", currency = "EUR" },
+                        remittanceInformationUnstructured = "Test payment",
+                        remittanceInformationUnstructuredArray = new[] { "Test payment" },
+                        internalTransactionId = "internal-1",
+                        bankTransactionCode = "PMNT"
+                    }
+                },
+                pending = Array.Empty<object>()
+            }
+        };
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(transactionsResponse,
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var result = await service.GetTransactionsAsync(accountId);
+
+        Assert.NotNull(result);
+        Assert.Single(result.BankTransactions.Booked);
+        Assert.Equal("tx-1", result.BankTransactions.Booked[0].TransactionId);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_UnauthorizedWithEuaMessage_ThrowsEndUserAgreementException()
+    {
+        var accountId = Guid.NewGuid();
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = new StringContent($"EUA was valid for 90 days and it expired {Guid.NewGuid()}")
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+
+        await Assert.ThrowsAsync<EndUserAgreementException>(() =>
+            service.GetTransactionsAsync(accountId));
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_ApiError_ThrowsException()
+    {
+        var accountId = Guid.NewGuid();
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            service.GetTransactionsAsync(accountId));
+    }
+
+    [Fact]
+    public async Task GetEndUserAgreement_Success_ReturnsAgreements()
+    {
+        var agreementsResponse = new
+        {
+            count = 1,
+            results = new[]
+            {
+                new
+                {
+                    id = "eua-1",
+                    created = DateTime.UtcNow,
+                    institution_id = "TEST_BANK",
+                    max_historical_days = 90,
+                    access_valid_for_days = 90,
+                    access_scope = new[] { "balances", "transactions" },
+                    accepted = (DateTime?)null,
+                    reconfirmation = false
+                }
+            }
+        };
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(agreementsResponse,
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var result = await service.GetEndUserAgreement();
+
+        Assert.NotNull(result);
+        Assert.Single(result.Results);
+        Assert.Equal("TEST_BANK", result.Results[0].InstitutionId);
+    }
+
+    [Fact]
+    public async Task CreateEndUserAgreement_Success_ReturnsAgreement()
+    {
+        var agreementResponse = new
+        {
+            id = "new-eua-id",
+            created = DateTime.UtcNow,
+            institution_id = "TEST_BANK",
+            max_historical_days = 30,
+            access_valid_for_days = 30,
+            access_scope = new[] { "balances", "transactions" },
+            accepted = (DateTime?)null,
+            reconfirmation = false
+        };
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(agreementResponse,
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var result = await service.CreateEndUserAgreement("TEST_BANK", 30);
+
+        Assert.NotNull(result);
+        Assert.Equal("new-eua-id", result.Id);
+        Assert.Equal("TEST_BANK", result.InstitutionId);
+    }
+
+    [Fact]
+    public async Task CreateRequisition_Success_ReturnsRequisition()
+    {
+        var requisitionResponse = new
+        {
+            id = "req-1",
+            created = DateTime.UtcNow,
+            redirect = "Banko://bank-auth-callback",
+            status = "CR",
+            institution_id = "TEST_BANK",
+            agreement = "agreement-1",
+            reference = "ref-1",
+            accounts = new[] { "acc-1" },
+            user_language = "EN",
+            link = "https://bank.link",
+            ssn = "",
+            account_selection = false,
+            redirect_immediate = false
+        };
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(requisitionResponse,
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var result = await service.CreateRequisition("TEST_BANK", "agreement-1");
+
+        Assert.NotNull(result);
+        Assert.Equal("req-1", result.Id);
+        Assert.Equal("TEST_BANK", result.InstitutionId);
+        Assert.Equal("agreement-1", result.Agreement);
+    }
+}

--- a/BankoApi.Tests/Services/GoCardlessTokenServiceTests.cs
+++ b/BankoApi.Tests/Services/GoCardlessTokenServiceTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Text.Json;
+using BankoApi.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+namespace BankoApi.Tests.Services;
+
+public class GoCardlessTokenServiceTests
+{
+    private Mock<HttpMessageHandler> CreateMessageHandlerMock(HttpStatusCode statusCode, object? responseContent)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(
+                    responseContent != null
+                        ? JsonSerializer.Serialize(responseContent, new JsonSerializerOptions
+                        {
+                            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                        })
+                        : "")
+            });
+        return handlerMock;
+    }
+
+    private GoCardlessTokenService CreateService(HttpMessageHandler handler, string? secretId = null, string? secretKey = null)
+    {
+        Environment.SetEnvironmentVariable("GOCARDLESS_ID", secretId ?? "test-id");
+        Environment.SetEnvironmentVariable("GOCARDLESS_KEY", secretKey ?? "test-key");
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.example.com/v1/")
+        };
+
+        var configMock = new Mock<IConfiguration>();
+        var loggerMock = new Mock<ILogger<GoCardlessTokenService>>();
+
+        return new GoCardlessTokenService(httpClient, configMock.Object, loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_NoCachedToken_RetrievesNewToken()
+    {
+        var tokenResponse = new
+        {
+            access = "new-access-token",
+            expires = 3600
+        };
+        var handlerMock = CreateMessageHandlerMock(HttpStatusCode.OK, tokenResponse);
+        var service = CreateService(handlerMock.Object);
+
+        var token = await service.GetAccessTokenAsync();
+
+        Assert.Equal("new-access-token", token);
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_CachedValidToken_ReturnsCachedToken()
+    {
+        var tokenResponse = new
+        {
+            access = "first-token",
+            expires = 3600
+        };
+        var handlerMock = CreateMessageHandlerMock(HttpStatusCode.OK, tokenResponse);
+        var service = CreateService(handlerMock.Object);
+
+        var firstToken = await service.GetAccessTokenAsync();
+        var secondToken = await service.GetAccessTokenAsync();
+
+        Assert.Equal("first-token", firstToken);
+        Assert.Equal("first-token", secondToken);
+
+        // Verify the handler was called only once (cached)
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_MissingCredentials_ThrowsInvalidOperationException()
+    {
+        Environment.SetEnvironmentVariable("GOCARDLESS_ID", "");
+        Environment.SetEnvironmentVariable("GOCARDLESS_KEY", "");
+
+        var handlerMock = CreateMessageHandlerMock(HttpStatusCode.OK, new { });
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("https://api.example.com/v1/")
+        };
+        var configMock = new Mock<IConfiguration>();
+        var loggerMock = new Mock<ILogger<GoCardlessTokenService>>();
+        var service = new GoCardlessTokenService(httpClient, configMock.Object, loggerMock.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetAccessTokenAsync());
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_ApiReturnsNullResponse_ThrowsInvalidOperationException()
+    {
+        var handlerMock = CreateMessageHandlerMock(HttpStatusCode.OK, new { access = (string?)null, expires = 0 });
+        var service = CreateService(handlerMock.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetAccessTokenAsync());
+    }
+}

--- a/BankoApi.Tests/Services/ScheduledTaskServiceTests.cs
+++ b/BankoApi.Tests/Services/ScheduledTaskServiceTests.cs
@@ -1,0 +1,177 @@
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using BankoApi.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace BankoApi.Tests.Services;
+
+public class ScheduledTaskServiceTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    private IServiceScope CreateScope(BankoDbContext ctx, GoCardlessService goCardlessService)
+    {
+        var serviceProviderMock = new Mock<IServiceProvider>();
+        serviceProviderMock.Setup(x => x.GetService(typeof(BankoDbContext)))
+            .Returns(ctx);
+        serviceProviderMock.Setup(x => x.GetService(typeof(GoCardlessService)))
+            .Returns(goCardlessService);
+
+        var scopeMock = new Mock<IServiceScope>();
+        scopeMock.Setup(x => x.ServiceProvider).Returns(serviceProviderMock.Object);
+
+        return scopeMock.Object;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoUsers_CompletesWithoutError()
+    {
+        using var ctx = CreateContext();
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var scope = CreateScope(ctx, service);
+
+        var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+        scopeFactoryMock.Setup(x => x.CreateScope()).Returns(scope);
+
+        var scheduledService = new ScheduledTaskService(scopeFactoryMock.Object);
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(100);
+
+        await scheduledService.StartAsync(cts.Token);
+        await Task.Delay(200);
+        await scheduledService.StopAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithUsersAndBankAccounts_ProcessesTransactions()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAuthId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            BankAccounts = new List<BankAccount>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    BankAuthorizationId = bankAuthId,
+                    BankAccountId = Guid.NewGuid().ToString(),
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                }
+            }
+        });
+        ctx.SaveChanges();
+
+        var transactionsResponse = new
+        {
+            transactions = new
+            {
+                booked = Array.Empty<object>(),
+                pending = Array.Empty<object>()
+            }
+        };
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new System.Net.Http.StringContent(
+                    System.Text.Json.JsonSerializer.Serialize(transactionsResponse,
+                        new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }))
+            });
+
+        var goCardlessService = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var scope = CreateScope(ctx, goCardlessService);
+
+        var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+        scopeFactoryMock.Setup(x => x.CreateScope()).Returns(scope);
+
+        var scheduledService = new ScheduledTaskService(scopeFactoryMock.Object);
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(100);
+
+        await scheduledService.StartAsync(cts.Token);
+        await Task.Delay(200);
+        await scheduledService.StopAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExceptionInFetch_DoesNotCrashService()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAuthId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            BankAccounts = new List<BankAccount>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    BankAuthorizationId = bankAuthId,
+                    BankAccountId = Guid.NewGuid().ToString(),
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                }
+            }
+        });
+        ctx.SaveChanges();
+
+        // Return 500 to cause exception in GetTransactionsAsync
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError));
+
+        var goCardlessService = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var scope = CreateScope(ctx, goCardlessService);
+
+        var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+        scopeFactoryMock.Setup(x => x.CreateScope()).Returns(scope);
+
+        var scheduledService = new ScheduledTaskService(scopeFactoryMock.Object);
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(100);
+
+        await scheduledService.StartAsync(cts.Token);
+        await Task.Delay(200);
+        await scheduledService.StopAsync(cts.Token);
+    }
+}

--- a/BankoApi.Tests/Utilities/ControllerExtensionsTests.cs
+++ b/BankoApi.Tests/Utilities/ControllerExtensionsTests.cs
@@ -1,0 +1,39 @@
+using BankoApi.Controllers.BankoApi.Controllers.Responses;
+using BankoApi.Controllers.BankoApi.Utils;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BankoApi.Tests.Utilities;
+
+public class ControllerExtensionsTests
+{
+    private class TestController : ControllerBase
+    {
+    }
+
+    [Fact]
+    public void Forbidden_WithErrorResponse_ReturnsStatusCode403()
+    {
+        var controller = new TestController();
+        var errorResponse = new ErrorResponse { Message = "Forbidden" };
+
+        var result = controller.Forbidden(errorResponse);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, objectResult.StatusCode);
+        var response = Assert.IsType<ErrorResponse>(objectResult.Value);
+        Assert.Equal("Forbidden", response.Message);
+    }
+
+    [Fact]
+    public void Forbidden_WithMessage_ReturnsStatusCode403()
+    {
+        var controller = new TestController();
+
+        var result = controller.Forbidden("Access denied");
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, objectResult.StatusCode);
+        var response = Assert.IsType<ErrorResponse>(objectResult.Value);
+        Assert.Equal("Access denied", response.Message);
+    }
+}

--- a/BankoApi.Tests/Utilities/TransactionExtensionsTests.cs
+++ b/BankoApi.Tests/Utilities/TransactionExtensionsTests.cs
@@ -1,0 +1,202 @@
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using BankoApi.Services.Model;
+using Microsoft.EntityFrameworkCore;
+using PendingDto = BankoApi.Services.Model.Pending;
+using ServiceCreditorAccount = BankoApi.Services.Model.CreditorAccount;
+using ServiceDebtorAccount = BankoApi.Services.Model.DebtorAccount;
+
+namespace BankoApi.Tests.Utilities;
+
+public class TransactionExtensionsTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    [Fact]
+    public void ToTransactionDao_BookedTransactions_ReturnsDaoList()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    new()
+                    {
+                        TransactionId = "tx-1",
+                        BookingDate = "2024-06-15",
+                        ValueDate = "2024-06-15",
+                        TransactionAmount = new TransactionAmount
+                        {
+                            Amount = "250.00",
+                            Currency = "EUR"
+                        },
+                        RemittanceInformationUnstructured = "Salary",
+                        RemittanceInformationUnstructuredArray = new List<string> { "Salary" },
+                        InternalTransactionId = "int-1",
+                        BankTransactionCode = "PMNT",
+                        CreditorName = "Employer",
+                        CreditorAccount = new ServiceCreditorAccount
+                        {
+                            Iban = "DE89370400440532013000",
+                            Bban = "00000000000"
+                        }
+                    }
+                },
+                Pending = new List<PendingDto>()
+            }
+        };
+
+        var result = transactions.ToTransactionDao(ctx, userId, bankAccountId);
+
+        Assert.Single(result);
+        var dao = result[0];
+        Assert.Equal("tx-1", dao.Id);
+        Assert.Equal(userId, dao.UserId);
+        Assert.Equal(bankAccountId, dao.BankAccountId);
+        Assert.Equal("250.00", dao.Amount);
+        Assert.Equal("EUR", dao.Currency);
+        Assert.Equal("Salary", dao.RemittanceInformationUnstructured);
+        Assert.Equal("Employer", dao.CreditorName);
+        Assert.NotNull(dao.CreditorAccount);
+        Assert.Equal("DE89370400440532013000", dao.CreditorAccount.Iban);
+    }
+
+    [Fact]
+    public void ToTransactionDao_EmptyBooked_ReturnsEmptyList()
+    {
+        using var ctx = CreateContext();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>(),
+                Pending = new List<PendingDto>()
+            }
+        };
+
+        var result = transactions.ToTransactionDao(ctx, Guid.NewGuid(), Guid.NewGuid());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ToTransactionDao_DebtorAccount_FindsOrCreatesDebtorAccount()
+    {
+        using var ctx = CreateContext();
+        var existingIban = "EXISTINGIBAN123";
+        ctx.DebtorAccounts.Add(new BankoApi.Data.Dao.DebtorAccount
+        {
+            Id = Guid.NewGuid(),
+            Iban = existingIban,
+            Bban = "existing-bban"
+        });
+        ctx.SaveChanges();
+
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    new()
+                    {
+                        TransactionId = "tx-debtor",
+                        BookingDate = "2024-06-15",
+                        ValueDate = "2024-06-15",
+                        TransactionAmount = new TransactionAmount
+                        {
+                            Amount = "100.00",
+                            Currency = "EUR"
+                        },
+                        RemittanceInformationUnstructured = "Test",
+                        RemittanceInformationUnstructuredArray = new List<string> { "Test" },
+                        InternalTransactionId = "int-debtor",
+                        DebtorAccount = new ServiceDebtorAccount
+                        {
+                            Iban = existingIban,
+                            Bban = "existing-bban"
+                        }
+                    }
+                },
+                Pending = new List<PendingDto>()
+            }
+        };
+
+        var result = transactions.ToTransactionDao(ctx, Guid.NewGuid(), Guid.NewGuid());
+
+        Assert.Single(result);
+        Assert.NotNull(result[0].DebtorAccount);
+        Assert.Equal(existingIban, result[0].DebtorAccount.Iban);
+    }
+
+    [Fact]
+    public void ToPendingDao_PendingTransactions_ReturnsDaoList()
+    {
+        var pendings = new List<PendingDto>
+        {
+            new()
+            {
+                BookingDate = "2024-06-20",
+                TransactionAmount = new TransactionAmount
+                {
+                    Amount = "75.00",
+                    Currency = "EUR"
+                },
+                RemittanceInformationUnstructured = "Pending tx",
+                RemittanceInformationUnstructuredArray = new List<string> { "Pending tx" }
+            }
+        };
+
+        var result = pendings.ToPendingDao();
+
+        Assert.Single(result);
+        Assert.Equal("75.00", result[0].Amount);
+        Assert.Equal("EUR", result[0].Currency);
+    }
+
+    [Fact]
+    public void ToPendingDao_EmptyList_ReturnsEmptyList()
+    {
+        var pendings = new List<PendingDto>();
+
+        var result = pendings.ToPendingDao();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ToPendingDao_NullableFields_NullCoalescingApplied()
+    {
+        var pendings = new List<PendingDto>
+        {
+            new()
+            {
+                BookingDate = "2024-06-20",
+                TransactionAmount = new TransactionAmount
+                {
+                    Amount = "50.00",
+                    Currency = "USD"
+                },
+                RemittanceInformationUnstructured = null,
+                RemittanceInformationUnstructuredArray = null
+            }
+        };
+
+        var result = pendings.ToPendingDao();
+
+        Assert.Single(result);
+        Assert.Equal("Transaction description not available", result[0].RemittanceInformationUnstructured);
+        Assert.Single(result[0].RemittanceInformationUnstructuredArray);
+    }
+}

--- a/BankoApi.Tests/Utilities/UtilsTests.cs
+++ b/BankoApi.Tests/Utilities/UtilsTests.cs
@@ -1,0 +1,20 @@
+using BankoApi;
+using Microsoft.AspNetCore.Builder;
+
+namespace BankoApi.Tests.Utilities;
+
+public class UtilsTests
+{
+    [Fact]
+    public void SelectDatabase_ReturnsConfiguredDatabaseName()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Configuration["GoogleCloud:DevDb"] = "BankoDb_Dev";
+
+        var result = Utils.SelectDatabase(builder);
+
+        // In Debug configuration, returns DevDb; in Release, returns Prod
+        // Since tests run in Debug, it should use DevDb
+        Assert.False(string.IsNullOrEmpty(result));
+    }
+}

--- a/BankoApi/Controllers/BankoApi/Controllers/TransacrionsController/TransactionsController.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/TransacrionsController/TransactionsController.cs
@@ -25,7 +25,12 @@ public class TransactionsController : ControllerBase
         DateTime? fromDate = null,
         DateTime? toDate = null)
     {
-        ValidateTransaction(pageNumber, pageSize, fromDate, toDate);
+        if (pageNumber < 1 || pageSize < 1)
+            return BadRequest("Page number and page size must be greater than zero.");
+
+        if (fromDate > toDate)
+            return BadRequest("The fromDate cannot be greater than toDate.");
+
         toDate ??= DateTime.UtcNow;
         fromDate ??= _dbContext.Transactions.Min(t => t.BookingDate);
 
@@ -73,18 +78,6 @@ public class TransactionsController : ControllerBase
         transaction.isDeleted = true;
         await _dbContext.SaveChangesAsync();
         return Ok("Transaction updated");
-    }
-
-    private void ValidateTransaction(int pageNumber, int pageSize, DateTime? fromDate, DateTime? toDate)
-    {
-        if (pageNumber < 1 || pageSize < 1)
-            throw new ArgumentException("Page number and page size must be greater than zero.");
-
-        if (fromDate != null)
-        {
-            toDate ??= DateTime.UtcNow;
-            if (fromDate > toDate) throw new ArgumentException("The fromDate cannot be greater than toDate.");
-        }
     }
 
     [HttpPut("expense-tag")]

--- a/BankoApi/Services/SheduledTaskService.cs
+++ b/BankoApi/Services/SheduledTaskService.cs
@@ -31,7 +31,7 @@ public class ScheduledTaskService : BackgroundService
 
             try
             {
-                FetchAndStoreTransactions();
+                await FetchAndStoreTransactions();
             }
             catch (Exception ex)
             {
@@ -41,7 +41,7 @@ public class ScheduledTaskService : BackgroundService
         }
     }
 
-    private async void FetchAndStoreTransactions()
+    private async Task FetchAndStoreTransactions()
     {
         using var scope = _scopeFactory.CreateScope();
         var goCardlessService = scope.ServiceProvider.GetRequiredService<GoCardlessService>();


### PR DESCRIPTION
## What

Two bug fixes in the backend:

1. **Fix `async void` in `ScheduledTaskService`** — `FetchAndStoreTransactions()` was declared `async void`, which crashes the process on any unhandled exception and cannot be awaited. Changed to `async Task` and added `await` to the call site.

2. **Fix uncaught `ArgumentException` in `TransactionsController.GetTransactions`** — validation failures (`pageNumber < 1`, `pageSize < 1`, `fromDate > toDate`) threw `ArgumentException`, which escaped as a 500 Internal Server Error. Replaced with direct `BadRequest` returns (400).

## Why

- `async void` is a known dangerous pattern in .NET — exceptions terminate the process
- Input validation should produce a proper 400 BadRequest, not a 500