### PR TITLE
Add global exception filter

### DIFF
--- a/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http;
 using System.Text.Json;
 using BankoApi.Controllers.GoCardless;
 using BankoApi.Data;
@@ -23,17 +24,30 @@ public class GoCardlessTransactionsControllerTests
     }
 
     [Fact]
-    public async Task FetchAndStoreTransactions_NoUser_ReturnsWithNoUser()
+    public async Task FetchAndStoreTransactions_NoUser_ThrowsArgumentNullException()
     {
         using var ctx = CreateContext();
-        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        var transactionsResponse = new
+        {
+            transactions = new
+            {
+                booked = Array.Empty<object>(),
+                pending = Array.Empty<object>()
+            }
+        };
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(transactionsResponse,
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         var controller = new TransactionsController(service, ctx, new TransactionsRepository(), Mock.Of<ILogger<TransactionsController>>());
         var bankAccountId = Guid.NewGuid();
 
-        var result = await controller.FetchAndStoreTransactions(bankAccountId);
-
-        Assert.IsType<BadRequestObjectResult>(result);
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            controller.FetchAndStoreTransactions(bankAccountId));
     }
 
     [Fact]
@@ -106,7 +120,7 @@ public class GoCardlessTransactionsControllerTests
     }
 
     [Fact]
-    public async Task FetchAndStoreTransactions_GeneralException_ReturnsBadRequest()
+    public async Task FetchAndStoreTransactions_GeneralException_ThrowsHttpRequestException()
     {
         using var ctx = CreateContext();
         ctx.Users.Add(new User
@@ -126,9 +140,8 @@ public class GoCardlessTransactionsControllerTests
         var controller = new TransactionsController(service, ctx, new TransactionsRepository(), Mock.Of<ILogger<TransactionsController>>());
         var bankAccountId = Guid.NewGuid();
 
-        var result = await controller.FetchAndStoreTransactions(bankAccountId);
-
-        Assert.IsType<BadRequestObjectResult>(result);
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            controller.FetchAndStoreTransactions(bankAccountId));
     }
 
     [Fact]

--- a/BankoApi/Controllers/BankoApi/Controllers/SettingsController/BankAccountController.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/SettingsController/BankAccountController.cs
@@ -14,10 +14,11 @@ namespace BankoApi.Controllers.BankoApi.Controllers.SettingsController.SettingsC
         [HttpGet("BankAccount")]
         public async Task<IActionResult> GetBankAccount([FromQuery] List<String> bankAccountId)
         {
+            if (bankAccountId.IsNullOrEmpty())
+                return BadRequest(new ErrorResponse() { Message = "Bank account IDs are required" });
+
             try
             {
-                if (bankAccountId.IsNullOrEmpty()) throw new ArgumentNullException(nameof(bankAccountId));
-
                 List<BankAccountResponse> bankAccounts = new List<BankAccountResponse>();
 
                 foreach (var id in bankAccountId)
@@ -48,71 +49,58 @@ namespace BankoApi.Controllers.BankoApi.Controllers.SettingsController.SettingsC
                 _logger.LogError(ex, "Bank account not found");
                 return NotFound(new ErrorResponse() { Message = GetBankAccountErrorMessages.AccountNotFound.ToString() });
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to get bank account");
-                return BadRequest(new ErrorResponse() { Message = ex.Message });
-            }
         }
 
         [HttpPut("BankAccount")]
         public async Task<IActionResult> UpsertBankAccount([FromBody] UpsertBankAccountRequest request)
         {
-            try
+            var account = await _dbContext.BankAccounts.FirstOrDefaultAsync(a => a.BankAccountId == request.BankAccountId)
+                ?? new BankAccount()
+                {
+                    BankAccountId = request.BankAccountId,
+                    BankAuthorizationId = request.BankAuthorizationId
+                };
+
+            if (request.Iban != null)
+                account.Iban = request.Iban;
+
+            if (request.Bban != null)
+                account.Bban = request.Bban;
+
+            if (request.OwnerName != null)
+                account.OwnerName = request.OwnerName;
+
+            if (request.Currency != null)
+                account.Currency = request.Currency;
+
+            if (request.Product != null)
+                account.Product = request.Product;
+
+            if (request.AccountName != null)
+                account.AccountName = request.AccountName;
+
+            if (account.Id == Guid.Empty)
             {
-                var account = await _dbContext.BankAccounts.FirstOrDefaultAsync(a => a.BankAccountId == request.BankAccountId)
-                    ?? new BankAccount()
-                    {
-                        BankAccountId = request.BankAccountId,
-                        BankAuthorizationId = request.BankAuthorizationId
-                    };
-
-                if (request.Iban != null)
-                    account.Iban = request.Iban;
-
-                if (request.Bban != null)
-                    account.Bban = request.Bban;
-
-                if (request.OwnerName != null)
-                    account.OwnerName = request.OwnerName;
-
-                if (request.Currency != null)
-                    account.Currency = request.Currency;
-
-                if (request.Product != null)
-                    account.Product = request.Product;
-
-                if (request.AccountName != null)
-                    account.AccountName = request.AccountName;
-
-                if (account.Id == Guid.Empty)
-                {
-                    _dbContext.Add(account);
-                }
-                else
-                {
-                    account.UpdatedAt = DateTime.UtcNow;
-                }
-
-                await _dbContext.SaveChangesAsync();
-
-                return Ok(new UpsertBankAccountResponse()
-                {
-                    BankAuthorizationId = account.BankAuthorizationId,
-                    BankAccountId = account.BankAccountId,
-                    Iban = account.Iban,
-                    Bban = account.Bban,
-                    OwnerName = account.OwnerName,
-                    Currency = account.Currency,
-                    Product = account.Product,
-                    AccountName = account.AccountName
-                });
+                _dbContext.Add(account);
             }
-            catch (Exception ex)
+            else
             {
-                _logger.LogError(ex, "Failed to upsert bank account");
-                return BadRequest(new ErrorResponse() { Message = ex.Message });
+                account.UpdatedAt = DateTime.UtcNow;
             }
+
+            await _dbContext.SaveChangesAsync();
+
+            return Ok(new UpsertBankAccountResponse()
+            {
+                BankAuthorizationId = account.BankAuthorizationId,
+                BankAccountId = account.BankAccountId,
+                Iban = account.Iban,
+                Bban = account.Bban,
+                OwnerName = account.OwnerName,
+                Currency = account.Currency,
+                Product = account.Product,
+                AccountName = account.AccountName
+            });
         }
     }
 }

--- a/BankoApi/Controllers/BankoApi/Controllers/SettingsController/BankAuthorizationController.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/SettingsController/BankAuthorizationController.cs
@@ -45,133 +45,97 @@ namespace BankoApi.Controllers.BankoApi.Controllers.SettingsController.SettingsC
                     Message = BankAuthorizationErrorMessages.NoAuthorizationFound.ToString(),
                 });
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to get bank authorization");
-                return BadRequest(new ErrorResponse
-                {
-                    Message = BankAuthorizationErrorMessages.SomethingWentWrong.ToString()
-                });
-            }
         }
 
         [HttpPut("BankAuthorization")]
         public async Task<IActionResult> UpsertBankAuthorization([FromBody] UpsertBankAuthorizationRequest request)
         {
-            try
+            if (!_dbContext.Users.Where(x => x.UserId == request.UserId).Any())
             {
-                if (!_dbContext.Users.Where(x => x.UserId == request.UserId).Any())
-                {
-                    return Unauthorized();
-                }
-                // Find or create the authorization
-                var authorization = await _dbContext.BankAuthorizations
-                    .FirstOrDefaultAsync(ba => ba.AgreementId == request.AgreementId)
-                    ?? new BankAuthorization { AgreementId = request.AgreementId };
-
-                authorization.Status = request.Status;
-
-                // Update fields if they're provided in the request
-                if (request.InstitutionId != null)
-                    authorization.InstitutionId = request.InstitutionId;
-
-                if (request.RequisitionId != null)
-                    authorization.RequisitionId = request.RequisitionId;
-
-                if (request.ReferenceId != null)
-                    authorization.ReferenceId = request.ReferenceId;
-
-                if (request.InstitutionName != null)
-                    authorization.InstitutionName = request.InstitutionName;
-
-
-                if (authorization.Id == Guid.Empty) // It's new
-                {
-                    authorization.UserId = request.UserId; // TODO(): Take it from the token
-                    _dbContext.BankAuthorizations.Add(authorization);
-                }
-                else
-                {
-                    authorization.UpdatedAt = DateTime.UtcNow;
-                }
-
-
-                await _dbContext.SaveChangesAsync();
-
-                return Ok(new UpsertBankAuthorizationResponse()
-                {
-                    Id = authorization.Id,
-                    UserId = authorization.UserId,
-                    RequisitionId = authorization.RequisitionId,
-                    InstitutionId = authorization.InstitutionId,
-                    Status = authorization.Status,
-                    AgreementId = authorization.AgreementId,
-                    ReferenceId = authorization.ReferenceId,
-                    InstitutionName = authorization.InstitutionName,
-                    CreatedAt = authorization.CreatedAt,
-                    UpdatedAt = authorization.UpdatedAt,
-                });
+                return Unauthorized();
             }
-            catch (Exception ex)
+
+            var authorization = await _dbContext.BankAuthorizations
+                .FirstOrDefaultAsync(ba => ba.AgreementId == request.AgreementId)
+                ?? new BankAuthorization { AgreementId = request.AgreementId };
+
+            authorization.Status = request.Status;
+
+            if (request.InstitutionId != null)
+                authorization.InstitutionId = request.InstitutionId;
+
+            if (request.RequisitionId != null)
+                authorization.RequisitionId = request.RequisitionId;
+
+            if (request.ReferenceId != null)
+                authorization.ReferenceId = request.ReferenceId;
+
+            if (request.InstitutionName != null)
+                authorization.InstitutionName = request.InstitutionName;
+
+            if (authorization.Id == Guid.Empty)
             {
-                _logger.LogError(ex, "Failed to upsert bank authorization");
-                return BadRequest(new ErrorResponse
-                {
-                    Message = BankAuthorizationErrorMessages.SomethingWentWrong.ToString()
-                });
+                authorization.UserId = request.UserId;
+                _dbContext.BankAuthorizations.Add(authorization);
             }
+            else
+            {
+                authorization.UpdatedAt = DateTime.UtcNow;
+            }
+
+            await _dbContext.SaveChangesAsync();
+
+            return Ok(new UpsertBankAuthorizationResponse()
+            {
+                Id = authorization.Id,
+                UserId = authorization.UserId,
+                RequisitionId = authorization.RequisitionId,
+                InstitutionId = authorization.InstitutionId,
+                Status = authorization.Status,
+                AgreementId = authorization.AgreementId,
+                ReferenceId = authorization.ReferenceId,
+                InstitutionName = authorization.InstitutionName,
+                CreatedAt = authorization.CreatedAt,
+                UpdatedAt = authorization.UpdatedAt,
+            });
         }
 
-        // TODO: Cambiare in PUT
         [HttpPost("end-user-agreement")]
         public async Task<IActionResult> UpsertEndUserAgreement([FromBody] UpsertEndUserAgreementRequest request)
         {
-            try
+            var eua = await _goCardlessService.GetEndUserAgreement();
+            EndUserAgreement? validEua = _repository.HasValidNonAcceptedAgreement(eua);
+
+            if (validEua == null)
             {
-                // Check del GET Eua, se ce n'è una o più valide resitituire quella con più giorni prima della prossima expire date.
-                // Se non ce n'è una disponibile, creare un nuovo EUA
-                // Creare una nuova Requisition contentente Agreement, Reference e Institution
-                // Salvare tutti i nuovi dati sul DB
-
-                var eua = await _goCardlessService.GetEndUserAgreement();
-                EndUserAgreement? validEua = _repository.HasValidNonAcceptedAgreement(eua);
-
-                if (validEua == null)
+                if (request.InstitutionId != null && request.DaysOfAccess != null)
                 {
-                    if (request.InstitutionId != null && request.DaysOfAccess != null)
-                    {
-                        validEua = await _goCardlessService.CreateEndUserAgreement(institutionId: request.InstitutionId, daysOfAccess: request.DaysOfAccess.Value);
-                    }
-                    else
-                    {
-                        String institutionId = "BIEN_SPAREBANK_BIENNOK1"; // TODO: prendere l'insitutionId dal DB
-                        int daysOfAccess = eua.Results.Where(e => e.InstitutionId == institutionId).First().AccessValidForDays;
-
-                        validEua = await _goCardlessService.CreateEndUserAgreement(institutionId: institutionId, daysOfAccess: daysOfAccess);
-                    }
+                    validEua = await _goCardlessService.CreateEndUserAgreement(institutionId: request.InstitutionId, daysOfAccess: request.DaysOfAccess.Value);
                 }
-
-                var requisition = await _goCardlessService.CreateRequisition(
-                    institutionId: validEua.InstitutionId,
-                    agreementId: validEua.Id
-                );
-
-                // TODO: Salvare sul DB tutte le info necessarie
-
-                return Ok(new UpsertEndUserAgreementResponse()
+                else
                 {
-                    AgreementId = requisition.Agreement,
-                    Link = requisition.Link,
-                    InstitutionId = requisition.InstitutionId,
-                    RequisitionId = requisition.Id,
-                    ReferenceId = requisition.Reference
-                });
+                    String institutionId = "BIEN_SPAREBANK_BIENNOK1"; // TODO: prendere l'insitutionId dal DB
+                    int daysOfAccess = eua.Results.Where(e => e.InstitutionId == institutionId).First().AccessValidForDays;
+
+                    validEua = await _goCardlessService.CreateEndUserAgreement(institutionId: institutionId, daysOfAccess: daysOfAccess);
+                }
             }
-            catch (Exception ex)
+
+            var requisition = await _goCardlessService.CreateRequisition(
+                institutionId: validEua.InstitutionId,
+                agreementId: validEua.Id
+            );
+
+            // TODO: Salvare sul DB tutte le info necessarie
+
+            return Ok(new UpsertEndUserAgreementResponse()
             {
-                _logger.LogError(ex, "Failed to upsert end user agreement");
-                return BadRequest(new ErrorResponse() { Message = ex.Message });
-            }
+                AgreementId = requisition.Agreement,
+                Link = requisition.Link,
+                InstitutionId = requisition.InstitutionId,
+                RequisitionId = requisition.Id,
+                ReferenceId = requisition.Reference
+            });
         }
     }
 }

--- a/BankoApi/Controllers/BankoApi/Controllers/UsersController/UsersController.cs
+++ b/BankoApi/Controllers/BankoApi/Controllers/UsersController/UsersController.cs
@@ -60,14 +60,6 @@ public class UsersController : ControllerBase
                 Message = UserErrorMessages.EmailAlreadyExists.ToString()
             });
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to create user");
-            return BadRequest(new ErrorResponse
-            {
-                Message = UserErrorMessages.SomethingWentWrong.ToString()
-            });
-        }
     }
 
     [HttpPost("login")]
@@ -99,14 +91,6 @@ public class UsersController : ControllerBase
             return this.Forbidden(new ErrorResponse
             {
                 Message = UserErrorMessages.InactiveAccount.ToString()
-            });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Login failed");
-            return BadRequest(new ErrorResponse
-            {
-                Message = UserErrorMessages.SomethingWentWrong.ToString()
             });
         }
     }

--- a/BankoApi/Controllers/GoCardless/TransactionsController.cs
+++ b/BankoApi/Controllers/GoCardless/TransactionsController.cs
@@ -48,10 +48,5 @@ public class TransactionsController : ControllerBase
                 Message = FetchAndStoreTransactionResponse.EndUserAgreementExpired.ToString()
             });
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to fetch and store transactions");
-            return BadRequest(new ErrorResponse() { Message = FetchAndStoreTransactionResponse.SomethingWentWrong.ToString() });
-        }
     }
 }

--- a/BankoApi/Filters/GlobalExceptionFilter.cs
+++ b/BankoApi/Filters/GlobalExceptionFilter.cs
@@ -1,0 +1,27 @@
+using BankoApi.Controllers.BankoApi.Controllers.Responses;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace BankoApi.Filters;
+
+public class GlobalExceptionFilter : IExceptionFilter
+{
+    private readonly ILogger<GlobalExceptionFilter> _logger;
+
+    public GlobalExceptionFilter(ILogger<GlobalExceptionFilter> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnException(ExceptionContext context)
+    {
+        _logger.LogError(context.Exception, "Unhandled exception");
+        context.Result = new ObjectResult(new ErrorResponse
+        {
+            Message = "Something went wrong"
+        })
+        {
+            StatusCode = 500
+        };
+    }
+}

--- a/BankoApi/Program.cs
+++ b/BankoApi/Program.cs
@@ -1,6 +1,7 @@
 using BankoApi;
 using BankoApi.Controllers.GoCardless;
 using BankoApi.Data;
+using BankoApi.Filters;
 using BankoApi.Logging;
 using BankoApi.Repository;
 using BankoApi.Services;
@@ -22,7 +23,10 @@ builder.Logging.AddConsole(o => o.FormatterName = "Custom");
 builder.Logging.AddConsoleFormatter<CustomConsoleFormatter, ConsoleFormatterOptions>();
 
 // Add services to the container.
-builder.Services.AddControllers().AddJsonOptions(options =>
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add<GlobalExceptionFilter>();
+}).AddJsonOptions(options =>
 {
     options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());


### PR DESCRIPTION
## What

Replaced the repetitive try-catch boilerplate with a **global exception filter** and removed 8 generic catch blocks across controllers.

**GlobalExceptionFilter** logs unhandled exceptions and returns 500 with a consistent `ErrorResponse` — guaranteeing no exception escapes as a raw 500.

**Kept** only the specific catches that have distinct HTTP semantics or side effects:
- `EndUserAgreementException` → 401 + marks EUA as expired in DB
- `BankAccountNotFoundException` → 404
- `NoBankAuthorizationFoundException` → 404
- `EmailConflictException` → 409
- `EmailNotFoundException` / `PasswordNotFoundException` → 401
- `InactiveUserException` → 403

**Also fixed:** `GetBankAccount` was throwing `ArgumentNullException` on empty input instead of returning `BadRequest` — replaced with proper validation.

## Why

- Removes ~80 lines of repetitive catch boilerplate
- Guarantees all unhandled exceptions return a consistent 500 response
- Prevents leaking exception details to clients
- Makes controller actions focused on the happy path only