### PR TITLE
Feature/user auth

### DIFF
--- a/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
@@ -1,10 +1,12 @@
 using System.Net;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Text.Json;
 using BankoApi.Controllers.GoCardless;
 using BankoApi.Data;
 using BankoApi.Data.Dao;
 using BankoApi.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using BankoApi.Repository;
@@ -23,55 +25,31 @@ public class GoCardlessTransactionsControllerTests
         return new BankoDbContext(options);
     }
 
-    [Fact]
-    public async Task FetchAndStoreTransactions_NoUser_ThrowsArgumentNullException()
+    private TransactionsController CreateController(BankoDbContext ctx, GoCardlessService service, Guid userId)
     {
-        using var ctx = CreateContext();
-        var transactionsResponse = new
-        {
-            transactions = new
-            {
-                booked = Array.Empty<object>(),
-                pending = Array.Empty<object>()
-            }
-        };
-
-        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
-            new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(JsonSerializer.Serialize(transactionsResponse,
-                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
-            });
-        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         var controller = new TransactionsController(service, ctx, new TransactionsRepository(), Mock.Of<ILogger<TransactionsController>>());
-        var bankAccountId = Guid.NewGuid();
-
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            controller.FetchAndStoreTransactions(bankAccountId));
+        var claims = new[] { new Claim(ClaimTypes.NameIdentifier, userId.ToString()) };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = principal }
+        };
+        return controller;
     }
 
     [Fact]
     public async Task FetchAndStoreTransactions_EmptyResponse_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        ctx.Users.Add(new User
-        {
-            UserId = Guid.NewGuid(),
-            Email = "test@example.com",
-            IsActive = true,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        });
-        ctx.SaveChanges();
-
-        // Return empty body which will deserialize as null Transactions
+        var userId = Guid.NewGuid();
         var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
             new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json")
             });
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
-        var controller = new TransactionsController(service, ctx, new TransactionsRepository(), Mock.Of<ILogger<TransactionsController>>());
+        var controller = CreateController(ctx, service, userId);
         var bankAccountId = Guid.NewGuid();
 
         var result = await controller.FetchAndStoreTransactions(bankAccountId);
@@ -111,7 +89,7 @@ public class GoCardlessTransactionsControllerTests
                 Content = new StringContent($"EUA was valid for 90 days and it expired {agreementId}")
             });
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
-        var controller = new TransactionsController(service, ctx, new TransactionsRepository(), Mock.Of<ILogger<TransactionsController>>());
+        var controller = CreateController(ctx, service, userId);
         var bankAccountId = Guid.NewGuid();
 
         var result = await controller.FetchAndStoreTransactions(bankAccountId);
@@ -123,21 +101,13 @@ public class GoCardlessTransactionsControllerTests
     public async Task FetchAndStoreTransactions_GeneralException_ThrowsHttpRequestException()
     {
         using var ctx = CreateContext();
-        ctx.Users.Add(new User
-        {
-            UserId = Guid.NewGuid(),
-            Email = "test@example.com",
-            IsActive = true,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        });
-        ctx.SaveChanges();
+        var userId = Guid.NewGuid();
 
         // Return 500 to cause HttpRequestException
         var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
             new HttpResponseMessage(HttpStatusCode.InternalServerError));
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
-        var controller = new TransactionsController(service, ctx, new TransactionsRepository(), Mock.Of<ILogger<TransactionsController>>());
+        var controller = CreateController(ctx, service, userId);
         var bankAccountId = Guid.NewGuid();
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
@@ -148,15 +118,7 @@ public class GoCardlessTransactionsControllerTests
     public async Task FetchAndStoreTransactions_Success_ReturnsOk()
     {
         using var ctx = CreateContext();
-        ctx.Users.Add(new User
-        {
-            UserId = Guid.NewGuid(),
-            Email = "test@example.com",
-            IsActive = true,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        });
-        ctx.SaveChanges();
+        var userId = Guid.NewGuid();
 
         var transactionsResponse = new
         {
@@ -174,7 +136,7 @@ public class GoCardlessTransactionsControllerTests
                     new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
             });
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
-        var controller = new TransactionsController(service, ctx, new TransactionsRepository(), Mock.Of<ILogger<TransactionsController>>());
+        var controller = CreateController(ctx, service, userId);
         var bankAccountId = Guid.NewGuid();
 
         var result = await controller.FetchAndStoreTransactions(bankAccountId);

--- a/BankoApi.Tests/Controllers/SettingsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/SettingsControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Security.Claims;
 using System.Text.Json;
 using BankoApi.Controllers.Settings.Requests;
 using BankoApi.Controllers.Settings.Responses;
@@ -10,6 +11,7 @@ using BankoApi.Data.Dao;
 using BankoApi.Repository;
 using BankoApi.Services;
 using BankoApi.Services.Model;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -28,14 +30,25 @@ public class SettingsControllerTests
         return new BankoDbContext(options);
     }
 
-    private SettingsController CreateController(BankoDbContext ctx, GoCardlessService? goCardlessService = null)
+    private SettingsController CreateController(BankoDbContext ctx, GoCardlessService? goCardlessService = null, Guid? userId = null)
     {
         if (goCardlessService == null)
         {
             var handlerMock = MockHelpers.CreateHandlerWithToken();
             goCardlessService = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         }
-        return new SettingsController(goCardlessService, ctx, new BankAuthorizationRepository(), Mock.Of<ILogger<SettingsController>>());
+        var controller = new SettingsController(goCardlessService, ctx, new BankAuthorizationRepository(), Mock.Of<ILogger<SettingsController>>());
+        if (userId.HasValue)
+        {
+            var claims = new[] { new Claim(ClaimTypes.NameIdentifier, userId.Value.ToString()) };
+            var identity = new ClaimsIdentity(claims, "TestAuth");
+            var principal = new ClaimsPrincipal(identity);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = principal }
+            };
+        }
+        return controller;
     }
 
     [Fact]
@@ -186,8 +199,8 @@ public class SettingsControllerTests
         });
         ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
-        var result = await controller.GetBankAuthorization(userId);
+        var controller = CreateController(ctx, userId: userId);
+        var result = await controller.GetBankAuthorization();
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsType<GetBankAuthorizationsResponse>(okResult.Value);
@@ -198,9 +211,9 @@ public class SettingsControllerTests
     public async Task GetBankAuthorization_NoAuthorizations_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: Guid.NewGuid());
 
-        var result = await controller.GetBankAuthorization(Guid.NewGuid());
+        var result = await controller.GetBankAuthorization();
 
         Assert.IsType<NotFoundObjectResult>(result);
     }

--- a/BankoApi.Tests/Controllers/UsersControllerTests.cs
+++ b/BankoApi.Tests/Controllers/UsersControllerTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using BankoApi.Controllers.Shared;
 using BankoApi.Controllers.Users;
 using BankoApi.Controllers.Users.Requests;
 using BankoApi.Controllers.Users.Responses;
@@ -5,6 +7,7 @@ using BankoApi.Data;
 using BankoApi.Data.Dao;
 using BankoApi.Repository;
 using BankoApi.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -208,5 +211,299 @@ public class UsersControllerTests
         var result = await controller.NewUser(request);
 
         Assert.IsType<OkObjectResult>(result);
+    }
+
+    // GDPR endpoint tests
+
+    private UsersController CreateAuthenticatedController(BankoDbContext ctx, Guid userId)
+    {
+        var controller = CreateController(ctx);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                }, "test"))
+            }
+        };
+        return controller;
+    }
+
+    private Guid SeedUser(BankoDbContext ctx)
+    {
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "gdpr@example.com",
+            PasswordHash = BCrypt.Net.BCrypt.EnhancedHashPassword("password12345", 12),
+            FullName = "GDPR User",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        ctx.SaveChanges();
+        return userId;
+    }
+
+    [Fact]
+    public void GetProfile_ReturnsProfile()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.GetProfile();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var profile = Assert.IsType<UserProfileResponse>(okResult.Value);
+        Assert.Equal(userId, profile.AccountId);
+        Assert.Equal("gdpr@example.com", profile.Email);
+        Assert.Equal("GDPR User", profile.FullName);
+    }
+
+    [Fact]
+    public void GetProfile_UserNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateAuthenticatedController(ctx, Guid.NewGuid());
+
+        var result = controller.GetProfile();
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void UpdateProfile_UpdatesFields()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.UpdateProfile(new UpdateProfileRequest
+        {
+            FullName = "Updated Name",
+            PhoneNumber = "123456789",
+            Address = "New Address"
+        });
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var profile = Assert.IsType<UserProfileResponse>(okResult.Value);
+        Assert.Equal("Updated Name", profile.FullName);
+        Assert.Equal("123456789", profile.PhoneNumber);
+        Assert.Equal("New Address", profile.Address);
+    }
+
+    [Fact]
+    public void UpdateProfile_PartialUpdate_OnlyChangesProvidedFields()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.UpdateProfile(new UpdateProfileRequest
+        {
+            FullName = "Only Name Changed"
+        });
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var profile = Assert.IsType<UserProfileResponse>(okResult.Value);
+        Assert.Equal("Only Name Changed", profile.FullName);
+        Assert.Null(profile.PhoneNumber);
+    }
+
+    [Fact]
+    public void UpdateProfile_UserNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateAuthenticatedController(ctx, Guid.NewGuid());
+
+        var result = controller.UpdateProfile(new UpdateProfileRequest
+        {
+            FullName = "Ghost"
+        });
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void ChangePassword_Valid_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.ChangePassword(new ChangePasswordRequest
+        {
+            CurrentPassword = "password12345",
+            NewPassword = "newpassword12345"
+        });
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public void ChangePassword_WrongCurrent_ReturnsUnauthorized()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.ChangePassword(new ChangePasswordRequest
+        {
+            CurrentPassword = "wrongpassword",
+            NewPassword = "newpassword12345"
+        });
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+    }
+
+    [Fact]
+    public void ChangePassword_UserNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateAuthenticatedController(ctx, Guid.NewGuid());
+
+        var result = controller.ChangePassword(new ChangePasswordRequest
+        {
+            CurrentPassword = "password12345",
+            NewPassword = "newpassword12345"
+        });
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void AcceptConsent_Valid_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var policyId = Guid.NewGuid();
+        ctx.PrivacyPolicyVersions.Add(new PrivacyPolicyVersion
+        {
+            Id = policyId,
+            Version = 1,
+            Title = "Privacy Policy v1",
+            PublishedAt = DateTime.UtcNow,
+            IsActive = true,
+        });
+        ctx.SaveChanges();
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.AcceptConsent(new AcceptConsentRequest
+        {
+            PolicyVersionId = policyId
+        });
+
+        Assert.IsType<OkResult>(result);
+
+        var user = ctx.Users.Find(userId);
+        Assert.True(user!.ConsentGiven);
+        Assert.Equal(policyId, user.ConsentVersionId);
+        Assert.NotNull(user.ConsentUpdatedAt);
+
+        var log = ctx.ConsentLogs.FirstOrDefault(cl => cl.UserId == userId);
+        Assert.NotNull(log);
+        Assert.True(log.Accepted);
+    }
+
+    [Fact]
+    public void AcceptConsent_PolicyNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.AcceptConsent(new AcceptConsentRequest
+        {
+            PolicyVersionId = Guid.NewGuid()
+        });
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void ExportData_ReturnsData()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.ExportData();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+    }
+
+    [Fact]
+    public void ExportData_WithConsentLogs_ReturnsLogs()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var policyId = Guid.NewGuid();
+        ctx.PrivacyPolicyVersions.Add(new PrivacyPolicyVersion
+        {
+            Id = policyId,
+            Version = 1,
+            Title = "Privacy Policy v1",
+            PublishedAt = DateTime.UtcNow,
+            IsActive = true,
+        });
+        ctx.SaveChanges();
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        controller.AcceptConsent(new AcceptConsentRequest { PolicyVersionId = policyId });
+        var result = controller.ExportData();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+        };
+        var json = System.Text.Json.JsonSerializer.Serialize(okResult.Value, options);
+        Assert.Contains("consentLogs", json);
+        Assert.Contains("Privacy Policy v1", json);
+    }
+
+    [Fact]
+    public void ExportData_UserNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateAuthenticatedController(ctx, Guid.NewGuid());
+
+        var result = controller.ExportData();
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void DeleteAccount_ReturnsOk()
+    {
+        using var ctx = CreateContext();
+        var userId = SeedUser(ctx);
+        var controller = CreateAuthenticatedController(ctx, userId);
+
+        var result = controller.DeleteAccount();
+
+        Assert.IsType<OkResult>(result);
+
+        var user = ctx.Users.Find(userId);
+        Assert.NotNull(user);
+        Assert.False(user!.IsActive);
+        Assert.Contains("deleted-", user.Email);
+        Assert.NotNull(user.DeletedAt);
+    }
+
+    [Fact]
+    public void DeleteAccount_UserNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateAuthenticatedController(ctx, Guid.NewGuid());
+
+        var result = controller.DeleteAccount();
+
+        Assert.IsType<NotFoundObjectResult>(result);
     }
 }

--- a/BankoApi.Tests/Controllers/UsersControllerTests.cs
+++ b/BankoApi.Tests/Controllers/UsersControllerTests.cs
@@ -1,9 +1,10 @@
 using BankoApi.Controllers.Users;
 using BankoApi.Controllers.Users.Requests;
+using BankoApi.Controllers.Users.Responses;
 using BankoApi.Data;
 using BankoApi.Data.Dao;
 using BankoApi.Repository;
-using Microsoft.AspNetCore.Identity.Data;
+using BankoApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,9 @@ namespace BankoApi.Tests.Controllers;
 
 public class UsersControllerTests
 {
+    private readonly Mock<TokenService> _tokenServiceMock = new(MockBehavior.Default, null!, null!);
+    private TokenService _tokenService => _tokenServiceMock.Object;
+
     private BankoDbContext CreateContext()
     {
         var options = new DbContextOptionsBuilder<BankoDbContext>()
@@ -21,11 +25,20 @@ public class UsersControllerTests
         return new BankoDbContext(options);
     }
 
+    private UsersController CreateController(BankoDbContext ctx)
+    {
+        _tokenServiceMock
+            .Setup(t => t.GenerateTokens(It.IsAny<User>()))
+            .Returns(("test-access-token", "test-refresh-token", 900L));
+
+        return new UsersController(ctx, new UserRepository(), _tokenService, Mock.Of<ILogger<UsersController>>());
+    }
+
     [Fact]
     public async Task NewUser_ValidRequest_ReturnsOkWithUserId()
     {
         using var ctx = CreateContext();
-        var controller = new UsersController(ctx, new UserRepository(), Mock.Of<ILogger<UsersController>>());
+        var controller = CreateController(ctx);
 
         var request = new NewUserRequest
         {
@@ -46,10 +59,9 @@ public class UsersControllerTests
     public async Task NewUser_DuplicateEmail_ReturnsConflict()
     {
         using var ctx = CreateContext();
-        var userId = Guid.NewGuid();
         ctx.Users.Add(new User
         {
-            UserId = userId,
+            UserId = Guid.NewGuid(),
             Email = "existing@example.com",
             IsActive = true,
             CreatedAt = DateTime.UtcNow,
@@ -57,7 +69,7 @@ public class UsersControllerTests
         });
         ctx.SaveChanges();
 
-        var controller = new UsersController(ctx, new UserRepository(), Mock.Of<ILogger<UsersController>>());
+        var controller = CreateController(ctx);
         var request = new NewUserRequest
         {
             Email = "existing@example.com",
@@ -73,7 +85,7 @@ public class UsersControllerTests
     public async Task Login_ValidCredentials_ReturnsOk()
     {
         using var ctx = CreateContext();
-        var controller = new UsersController(ctx, new UserRepository(), Mock.Of<ILogger<UsersController>>());
+        var controller = CreateController(ctx);
 
         // Create user first via the controller
         var createRequest = new NewUserRequest
@@ -96,10 +108,44 @@ public class UsersControllerTests
     }
 
     [Fact]
+    public async Task Login_ReturnsRealTokens()
+    {
+        using var ctx = CreateContext();
+        var controller = CreateController(ctx);
+
+        var createRequest = new NewUserRequest
+        {
+            Email = "token-test@example.com",
+            Password = "password12345"
+        };
+        var createResult = await controller.NewUser(createRequest);
+        var createOk = Assert.IsType<OkObjectResult>(createResult);
+        var createResponse = Assert.IsType<UserResponse>(createOk.Value);
+
+        Assert.Equal("test-access-token", createResponse.AccessToken);
+        Assert.Equal("test-refresh-token", createResponse.RefreshToken);
+        Assert.Equal(900L, createResponse.ExpiresIn);
+        Assert.NotEqual(Guid.Empty, createResponse.AccountId);
+
+        var loginResult = await controller.Login(new LoginRequest
+        {
+            Email = "token-test@example.com",
+            Password = "password12345"
+        });
+        var loginOk = Assert.IsType<OkObjectResult>(loginResult);
+        var loginResponse = Assert.IsType<UserResponse>(loginOk.Value);
+
+        Assert.Equal("test-access-token", loginResponse.AccessToken);
+        Assert.Equal("test-refresh-token", loginResponse.RefreshToken);
+        Assert.Equal(900L, loginResponse.ExpiresIn);
+        Assert.NotEqual(Guid.Empty, loginResponse.AccountId);
+    }
+
+    [Fact]
     public async Task Login_WrongCredentials_ReturnsUnauthorized()
     {
         using var ctx = CreateContext();
-        var controller = new UsersController(ctx, new UserRepository(), Mock.Of<ILogger<UsersController>>());
+        var controller = CreateController(ctx);
 
         var createRequest = new NewUserRequest
         {
@@ -134,7 +180,7 @@ public class UsersControllerTests
         });
         ctx.SaveChanges();
 
-        var controller = new UsersController(ctx, new UserRepository(), Mock.Of<ILogger<UsersController>>());
+        var controller = CreateController(ctx);
         var loginRequest = new LoginRequest
         {
             Email = "inactive@example.com",
@@ -151,7 +197,7 @@ public class UsersControllerTests
     public async Task NewUser_MinimalData_ReturnsOk()
     {
         using var ctx = CreateContext();
-        var controller = new UsersController(ctx, new UserRepository(), Mock.Of<ILogger<UsersController>>());
+        var controller = CreateController(ctx);
 
         var request = new NewUserRequest
         {

--- a/BankoApi.Tests/Services/TokenServiceTests.cs
+++ b/BankoApi.Tests/Services/TokenServiceTests.cs
@@ -1,0 +1,219 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using BankoApi.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace BankoApi.Tests.Services;
+
+public class TokenServiceTests
+{
+    private BankoDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<BankoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new BankoDbContext(options);
+    }
+
+    private IConfiguration CreateConfig()
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = "This-Is-A-Test-Secret-Key-That-Is-At-Least-32-Chars!",
+                ["Jwt:Issuer"] = "TestIssuer",
+                ["Jwt:Audience"] = "TestAudience",
+                ["Jwt:AccessTokenExpirationMinutes"] = "15",
+                ["Jwt:RefreshTokenExpirationDays"] = "7"
+            })!
+            .Build();
+    }
+
+    private User CreateUser(BankoDbContext ctx)
+    {
+        var user = new User
+        {
+            UserId = Guid.NewGuid(),
+            Email = "test@example.com",
+            PasswordHash = BCrypt.Net.BCrypt.EnhancedHashPassword("password12345", 12),
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Users.Add(user);
+        ctx.SaveChanges();
+        return user;
+    }
+
+    [Fact]
+    public void GenerateTokens_ReturnsValidTokens()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+
+        var (accessToken, refreshToken, expiresIn) = service.GenerateTokens(user);
+
+        Assert.NotEmpty(accessToken);
+        Assert.NotEmpty(refreshToken);
+        Assert.Equal(900L, expiresIn);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(accessToken);
+        Assert.Equal(user.UserId.ToString(), jwt.Claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value);
+        Assert.Equal(user.Email, jwt.Claims.First(c => c.Type == ClaimTypes.Email).Value);
+        Assert.NotEmpty(jwt.Id);
+    }
+
+    [Fact]
+    public void GenerateTokens_CreatesRefreshTokenInDb()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+
+        service.GenerateTokens(user);
+
+        var storedToken = ctx.RefreshTokens.FirstOrDefault(rt => rt.UserId == user.UserId);
+        Assert.NotNull(storedToken);
+        Assert.False(storedToken.IsUsed);
+        Assert.False(storedToken.IsRevoked);
+        Assert.Equal(user.UserId, storedToken.UserId);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ValidToken_ReturnsNewTokens()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, originalRefresh, _) = service.GenerateTokens(user);
+
+        var (userId, accessToken, refreshToken, expiresIn) = await service.RefreshTokenAsync(originalRefresh);
+
+        Assert.Equal(user.UserId, userId);
+        Assert.NotEmpty(accessToken);
+        Assert.NotEmpty(refreshToken);
+        Assert.NotEqual(originalRefresh, refreshToken);
+        Assert.Equal(900L, expiresIn);
+
+        var oldToken = ctx.RefreshTokens.FirstOrDefault(rt => rt.Token == originalRefresh);
+        Assert.NotNull(oldToken);
+        Assert.True(oldToken.IsUsed);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ExpiredToken_Throws()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+
+        var expiredToken = new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.UserId,
+            Token = Convert.ToBase64String(new byte[64]),
+            JwtId = Guid.NewGuid().ToString(),
+            CreatedAt = DateTime.UtcNow.AddDays(-10),
+            ExpiresAt = DateTime.UtcNow.AddDays(-3),
+            IsUsed = false,
+            IsRevoked = false,
+        };
+        ctx.RefreshTokens.Add(expiredToken);
+        ctx.SaveChanges();
+
+        await Assert.ThrowsAsync<SecurityTokenException>(() =>
+            service.RefreshTokenAsync(expiredToken.Token));
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_UsedToken_RevokesAll()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, firstRefresh, _) = service.GenerateTokens(user);
+        var (_, secondRefresh, _) = service.GenerateTokens(user);
+
+        var usedToken = ctx.RefreshTokens.First(rt => rt.Token == firstRefresh);
+        usedToken.IsUsed = true;
+        ctx.SaveChanges();
+
+        await Assert.ThrowsAsync<SecurityTokenException>(() =>
+            service.RefreshTokenAsync(firstRefresh));
+
+        var allTokens = ctx.RefreshTokens.Where(rt => rt.UserId == user.UserId).ToList();
+        Assert.All(allTokens, t => Assert.True(t.IsRevoked));
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_RevokedToken_Throws()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, refresh, _) = service.GenerateTokens(user);
+
+        var storedToken = ctx.RefreshTokens.First(rt => rt.Token == refresh);
+        storedToken.IsRevoked = true;
+        ctx.SaveChanges();
+
+        await Assert.ThrowsAsync<SecurityTokenException>(() =>
+            service.RefreshTokenAsync(refresh));
+    }
+
+    [Fact]
+    public async Task RevokeRefreshTokenAsync_RevokesToken()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, refresh, _) = service.GenerateTokens(user);
+
+        await service.RevokeRefreshTokenAsync(refresh);
+
+        var storedToken = ctx.RefreshTokens.First(rt => rt.Token == refresh);
+        Assert.True(storedToken.IsRevoked);
+    }
+
+    [Fact]
+    public async Task RevokeRefreshTokenAsync_NonExistentToken_DoesNotThrow()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+
+        await service.RevokeRefreshTokenAsync("nonexistent-token");
+    }
+
+    [Fact]
+    public void GenerateTokens_DefaultConfig_UsesDefaults()
+    {
+        using var ctx = CreateContext();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = "This-Is-A-Test-Secret-Key-That-Is-At-Least-32-Chars!",
+            })!
+            .Build();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+
+        var (accessToken, _, expiresIn) = service.GenerateTokens(user);
+
+        Assert.NotEmpty(accessToken);
+        Assert.Equal(900L, expiresIn);
+    }
+}

--- a/BankoApi/BankoApi.csproj
+++ b/BankoApi/BankoApi.csproj
@@ -9,6 +9,8 @@
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="DotNetEnv" Version="3.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.10" />

--- a/BankoApi/Controllers/GoCardless/TransactionsController.cs
+++ b/BankoApi/Controllers/GoCardless/TransactionsController.cs
@@ -4,11 +4,13 @@ using BankoApi.Data;
 using BankoApi.Exceptions.GoCardless.Transactions;
 using BankoApi.Repository;
 using BankoApi.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BankoApi.Controllers.GoCardless;
 
 [ApiController]
+[Authorize]
 [Route("gocardless/[controller]")]
 public class TransactionsController : ControllerBase
 {
@@ -31,7 +33,7 @@ public class TransactionsController : ControllerBase
         try
         {
             var transactions = await _goCardlessService.GetTransactionsAsync(bankAccountId);
-            Guid userId = _dbContext.Users.FirstOrDefault()?.UserId ?? throw new ArgumentNullException(nameof(bankAccountId));
+            Guid userId = User.GetUserId();
 
             if (transactions == null) return NotFound(FetchAndStoreTransactionResponse.NoTransactionsFound.ToString());
             await _repository.StoreTransactions(ctx: _dbContext, userId: userId, bankAccountId: bankAccountId, transactions);

--- a/BankoApi/Controllers/Settings/BankAccountController.cs
+++ b/BankoApi/Controllers/Settings/BankAccountController.cs
@@ -14,7 +14,7 @@ namespace BankoApi.Controllers.Settings
         [HttpGet("BankAccount")]
         public async Task<IActionResult> GetBankAccount([FromQuery] List<String> bankAccountId)
         {
-            if (bankAccountId.IsNullOrEmpty())
+            if (bankAccountId.Count == 0)
                 return BadRequest(new ErrorResponse() { Message = "Bank account IDs are required" });
 
             try

--- a/BankoApi/Controllers/Settings/BankAuthorizationController.cs
+++ b/BankoApi/Controllers/Settings/BankAuthorizationController.cs
@@ -14,10 +14,11 @@ namespace BankoApi.Controllers.Settings
     public partial class SettingsController
     {
         [HttpGet("BankAuthorization")]
-        public async Task<IActionResult> GetBankAuthorization(Guid userId)
+        public async Task<IActionResult> GetBankAuthorization()
         {
             try
             {
+                var userId = User.GetUserId();
                 var result = _dbContext.BankAuthorizations.Where(ba => ba.UserId == userId).ToList();
                 if (result.Count == 0) throw new NoBankAuthorizationFoundException($"The user {userId} doesn't have any bank authorization process started yet.");
                 return Ok(new GetBankAuthorizationsResponse

--- a/BankoApi/Controllers/Settings/SettingsController.cs
+++ b/BankoApi/Controllers/Settings/SettingsController.cs
@@ -2,11 +2,13 @@ using BankoApi.Data;
 using BankoApi.Data.Dao;
 using BankoApi.Repository;
 using BankoApi.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BankoApi.Controllers.Settings;
 
 [ApiController]
+[Authorize]
 [Route("[controller]")]
 public partial class SettingsController : ControllerBase
 {

--- a/BankoApi/Controllers/Transactions/TransactionsController.cs
+++ b/BankoApi/Controllers/Transactions/TransactionsController.cs
@@ -2,12 +2,14 @@ using BankoApi.Controllers.Settings.Requests;
 using BankoApi.Controllers.Transactions.Requests;
 using BankoApi.Data;
 using BankoApi.Services.Model;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace BankoApi.Controllers.Transactions;
 
 [ApiController]
+[Authorize]
 [Route("[controller]")]
 public class TransactionsController : ControllerBase
 {

--- a/BankoApi/Controllers/Users/Requests/AcceptConsentRequest.cs
+++ b/BankoApi/Controllers/Users/Requests/AcceptConsentRequest.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BankoApi.Controllers.Users.Requests;
+
+public class AcceptConsentRequest
+{
+    [Required] public Guid PolicyVersionId { get; set; }
+}

--- a/BankoApi/Controllers/Users/Requests/ChangePasswordRequest.cs
+++ b/BankoApi/Controllers/Users/Requests/ChangePasswordRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BankoApi.Controllers.Users.Requests;
+
+public class ChangePasswordRequest
+{
+    [Required] public string CurrentPassword { get; set; } = string.Empty;
+
+    [Required] [MinLength(10)] public string NewPassword { get; set; } = string.Empty;
+}

--- a/BankoApi/Controllers/Users/Requests/LoginRequest.cs
+++ b/BankoApi/Controllers/Users/Requests/LoginRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BankoApi.Controllers.Users.Requests;
+
+public class LoginRequest
+{
+    [Required] [EmailAddress] public string Email { get; set; } = string.Empty;
+
+    [Required] public string Password { get; set; } = string.Empty;
+}

--- a/BankoApi/Controllers/Users/Requests/RefreshTokenRequest.cs
+++ b/BankoApi/Controllers/Users/Requests/RefreshTokenRequest.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BankoApi.Controllers.Users.Requests;
+
+public class RefreshTokenRequest
+{
+    [Required] public string RefreshToken { get; set; } = string.Empty;
+}

--- a/BankoApi/Controllers/Users/Requests/UpdateProfileRequest.cs
+++ b/BankoApi/Controllers/Users/Requests/UpdateProfileRequest.cs
@@ -1,0 +1,10 @@
+namespace BankoApi.Controllers.Users.Requests;
+
+public class UpdateProfileRequest
+{
+    public string? FullName { get; set; }
+
+    public string? PhoneNumber { get; set; }
+
+    public string? Address { get; set; }
+}

--- a/BankoApi/Controllers/Users/Responses/UserProfileResponse.cs
+++ b/BankoApi/Controllers/Users/Responses/UserProfileResponse.cs
@@ -1,0 +1,16 @@
+namespace BankoApi.Controllers.Users.Responses;
+
+public class UserProfileResponse
+{
+    public Guid AccountId { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string? FullName { get; set; }
+    public string? PhoneNumber { get; set; }
+    public string? Address { get; set; }
+    public bool ConsentGiven { get; set; }
+    public DateTime? ConsentUpdatedAt { get; set; }
+    public Guid? ConsentVersionId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? LastLoginAt { get; set; }
+}

--- a/BankoApi/Controllers/Users/Responses/UserResponse.cs
+++ b/BankoApi/Controllers/Users/Responses/UserResponse.cs
@@ -3,8 +3,8 @@ namespace BankoApi.Controllers.Users.Responses;
 public class UserResponse
 {
     public Guid AccountId { get; set; }
-    public string AccessToken { get; set; }
-    public string RefreshToken { get; set; }
+    public required string AccessToken { get; set; }
+    public required string RefreshToken { get; set; }
     public long ExpiresIn { get; set; }
 }
 

--- a/BankoApi/Controllers/Users/UsersController.cs
+++ b/BankoApi/Controllers/Users/UsersController.cs
@@ -3,11 +3,13 @@ using BankoApi.Controllers.Users.Requests;
 using BankoApi.Controllers.Users.Responses;
 using BankoApi.Controllers.Shared.DTO;
 using BankoApi.Data;
+using BankoApi.Data.Dao;
 using BankoApi.Exceptions.User;
 using BankoApi.Repository;
 using BankoApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 
 namespace BankoApi.Controllers.Users;
@@ -144,5 +146,176 @@ public class UsersController : ControllerBase
     {
         await _tokenService.RevokeRefreshTokenAsync(request.RefreshToken);
         return Ok();
+    }
+
+    [Authorize]
+    [HttpGet("me")]
+    public IActionResult GetProfile()
+    {
+        var userId = User.GetUserId();
+        var user = _dbContext.Users.Find(userId);
+        if (user == null)
+            return NotFound(new ErrorResponse { Message = "User not found" });
+
+        return Ok(new UserProfileResponse
+        {
+            AccountId = user.UserId,
+            Email = user.Email,
+            FullName = user.FullName,
+            PhoneNumber = user.PhoneNumber,
+            Address = user.Address,
+            ConsentGiven = user.ConsentGiven,
+            ConsentUpdatedAt = user.ConsentUpdatedAt,
+            ConsentVersionId = user.ConsentVersionId,
+            CreatedAt = user.CreatedAt,
+            UpdatedAt = user.UpdatedAt,
+            LastLoginAt = user.LastLoginAt
+        });
+    }
+
+    [Authorize]
+    [HttpPut("me")]
+    public IActionResult UpdateProfile([FromBody] UpdateProfileRequest request)
+    {
+        var userId = User.GetUserId();
+        var user = _dbContext.Users.Find(userId);
+        if (user == null)
+            return NotFound(new ErrorResponse { Message = "User not found" });
+
+        if (request.FullName != null) user.FullName = request.FullName;
+        if (request.PhoneNumber != null) user.PhoneNumber = request.PhoneNumber;
+        if (request.Address != null) user.Address = request.Address;
+
+        user.UpdatedAt = DateTime.UtcNow;
+        _dbContext.SaveChanges();
+
+        return Ok(new UserProfileResponse
+        {
+            AccountId = user.UserId,
+            Email = user.Email,
+            FullName = user.FullName,
+            PhoneNumber = user.PhoneNumber,
+            Address = user.Address,
+            ConsentGiven = user.ConsentGiven,
+            ConsentUpdatedAt = user.ConsentUpdatedAt,
+            ConsentVersionId = user.ConsentVersionId,
+            CreatedAt = user.CreatedAt,
+            UpdatedAt = user.UpdatedAt,
+            LastLoginAt = user.LastLoginAt
+        });
+    }
+
+    [Authorize]
+    [HttpPut("me/password")]
+    public IActionResult ChangePassword([FromBody] ChangePasswordRequest request)
+    {
+        var userId = User.GetUserId();
+        try
+        {
+            _repository.UpdatePassword(_dbContext, userId, request.CurrentPassword, request.NewPassword);
+            return Ok();
+        }
+        catch (PasswordNotFoundException ex)
+        {
+            _logger.LogError(ex, "Wrong password");
+            return Unauthorized(new ErrorResponse
+            {
+                Message = UserErrorMessages.WrongCredentials.ToString()
+            });
+        }
+        catch (EmailNotFoundException ex)
+        {
+            _logger.LogError(ex, "User not found");
+            return NotFound(new ErrorResponse { Message = "User not found" });
+        }
+    }
+
+    [Authorize]
+    [HttpPut("me/consent")]
+    public IActionResult AcceptConsent([FromBody] AcceptConsentRequest request)
+    {
+        var userId = User.GetUserId();
+        var user = _dbContext.Users.Find(userId);
+        if (user == null)
+            return NotFound(new ErrorResponse { Message = "User not found" });
+
+        var policyVersion = _dbContext.PrivacyPolicyVersions.Find(request.PolicyVersionId);
+        if (policyVersion == null)
+            return NotFound(new ErrorResponse { Message = "Privacy policy version not found" });
+
+        var consentLog = new ConsentLog
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PrivacyPolicyVersionId = request.PolicyVersionId,
+            Accepted = true,
+            RecordedAt = DateTime.UtcNow
+        };
+        _dbContext.ConsentLogs.Add(consentLog);
+
+        user.ConsentGiven = true;
+        user.ConsentVersionId = request.PolicyVersionId;
+        user.ConsentUpdatedAt = DateTime.UtcNow;
+        user.UpdatedAt = DateTime.UtcNow;
+        _dbContext.SaveChanges();
+
+        return Ok();
+    }
+
+    [Authorize]
+    [HttpGet("me/export")]
+    public IActionResult ExportData()
+    {
+        var userId = User.GetUserId();
+        var user = _dbContext.Users.Find(userId);
+        if (user == null)
+            return NotFound(new ErrorResponse { Message = "User not found" });
+
+        var consentLogs = _dbContext.ConsentLogs
+            .Where(cl => cl.UserId == userId)
+            .Include(cl => cl.PrivacyPolicyVersion)
+            .Select(cl => new
+            {
+                PolicyVersion = cl.PrivacyPolicyVersion.Version,
+                PolicyTitle = cl.PrivacyPolicyVersion.Title,
+                Accepted = cl.Accepted,
+                RecordedAt = cl.RecordedAt
+            })
+            .ToList();
+
+        var export = new
+        {
+            AccountId = user.UserId,
+            Email = user.Email,
+            FullName = user.FullName,
+            PhoneNumber = user.PhoneNumber,
+            Address = user.Address,
+            ConsentGiven = user.ConsentGiven,
+            ConsentUpdatedAt = user.ConsentUpdatedAt,
+            ConsentVersionId = user.ConsentVersionId,
+            CreatedAt = user.CreatedAt,
+            UpdatedAt = user.UpdatedAt,
+            LastLoginAt = user.LastLoginAt,
+            ConsentLogs = consentLogs
+        };
+
+        return Ok(export);
+    }
+
+    [Authorize]
+    [HttpDelete("me")]
+    public IActionResult DeleteAccount()
+    {
+        var userId = User.GetUserId();
+        try
+        {
+            _repository.SoftDeleteUser(_dbContext, userId);
+            return Ok();
+        }
+        catch (EmailNotFoundException ex)
+        {
+            _logger.LogError(ex, "User not found");
+            return NotFound(new ErrorResponse { Message = "User not found" });
+        }
     }
 }

--- a/BankoApi/Controllers/Users/UsersController.cs
+++ b/BankoApi/Controllers/Users/UsersController.cs
@@ -5,8 +5,10 @@ using BankoApi.Controllers.Shared.DTO;
 using BankoApi.Data;
 using BankoApi.Exceptions.User;
 using BankoApi.Repository;
-using Microsoft.AspNetCore.Identity.Data;
+using BankoApi.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 
 namespace BankoApi.Controllers.Users;
 
@@ -16,15 +18,22 @@ public class UsersController : ControllerBase
 {
     private readonly BankoDbContext _dbContext;
     private readonly UserRepository _repository;
+    private readonly TokenService _tokenService;
     private readonly ILogger<UsersController> _logger;
 
-    public UsersController(BankoDbContext dbContext, UserRepository repository, ILogger<UsersController> logger)
+    public UsersController(
+        BankoDbContext dbContext,
+        UserRepository repository,
+        TokenService tokenService,
+        ILogger<UsersController> logger)
     {
         _dbContext = dbContext;
         _repository = repository;
+        _tokenService = tokenService;
         _logger = logger;
     }
 
+    [AllowAnonymous]
     [HttpPost]
     public async Task<IActionResult> NewUser([FromBody] NewUserRequest request)
     {
@@ -43,12 +52,16 @@ public class UsersController : ControllerBase
                 context: _dbContext
             );
             await _dbContext.SaveChangesAsync();
+
+            var user = _dbContext.Users.Find(userId)!;
+            var (accessToken, refreshToken, expiresIn) = _tokenService.GenerateTokens(user);
+
             return Ok(new UserResponse
             {
                 AccountId = userId,
-                AccessToken = "ACCESS_TOKEN",
-                RefreshToken = "REFRESH_TOKEN",
-                ExpiresIn = 1234567890
+                AccessToken = accessToken,
+                RefreshToken = refreshToken,
+                ExpiresIn = expiresIn
             });
         }
         catch (EmailConflictException ex)
@@ -61,6 +74,7 @@ public class UsersController : ControllerBase
         }
     }
 
+    [AllowAnonymous]
     [HttpPost("login")]
     public async Task<IActionResult> Login([FromBody] LoginRequest request)
     {
@@ -68,12 +82,15 @@ public class UsersController : ControllerBase
         {
             var userId = _repository.ValidateAccount(_dbContext, request.Email, request.Password);
 
+            var user = _dbContext.Users.Find(userId)!;
+            var (accessToken, refreshToken, expiresIn) = _tokenService.GenerateTokens(user);
+
             return Ok(new UserResponse
             {
                 AccountId = userId,
-                AccessToken = "ACCESS_TOKEN",
-                RefreshToken = "REFRESH_TOKEN",
-                ExpiresIn = 1234567890
+                AccessToken = accessToken,
+                RefreshToken = refreshToken,
+                ExpiresIn = expiresIn
             });
         }
         catch (Exception ex) when (ex is EmailNotFoundException || ex is PasswordNotFoundException)
@@ -92,5 +109,40 @@ public class UsersController : ControllerBase
                 Message = UserErrorMessages.InactiveAccount.ToString()
             });
         }
+    }
+
+    [AllowAnonymous]
+    [HttpPost("refresh")]
+    public async Task<IActionResult> Refresh([FromBody] RefreshTokenRequest request)
+    {
+        try
+        {
+            var (userId, accessToken, refreshToken, expiresIn) =
+                await _tokenService.RefreshTokenAsync(request.RefreshToken);
+
+            return Ok(new UserResponse
+            {
+                AccountId = userId,
+                AccessToken = accessToken,
+                RefreshToken = refreshToken,
+                ExpiresIn = expiresIn
+            });
+        }
+        catch (SecurityTokenException ex)
+        {
+            _logger.LogError(ex, "Token refresh failed");
+            return Unauthorized(new ErrorResponse
+            {
+                Message = UserErrorMessages.SomethingWentWrong.ToString()
+            });
+        }
+    }
+
+    [Authorize]
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout([FromBody] RefreshTokenRequest request)
+    {
+        await _tokenService.RevokeRefreshTokenAsync(request.RefreshToken);
+        return Ok();
     }
 }

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -19,6 +19,8 @@ public class BankoDbContext : DbContext
     public DbSet<BankAuthorization> BankAuthorizations { get; set; }
     public DbSet<Pending> Pendings { get; set; }
     public DbSet<RefreshToken> RefreshTokens { get; set; }
+    public DbSet<PrivacyPolicyVersion> PrivacyPolicyVersions { get; set; }
+    public DbSet<ConsentLog> ConsentLogs { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -82,6 +84,32 @@ public class BankoDbContext : DbContext
                   .WithMany()
                   .HasForeignKey(rt => rt.UserId)
                   .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<PrivacyPolicyVersion>(entity =>
+        {
+            entity.HasIndex(p => p.Version).IsUnique();
+        });
+
+        modelBuilder.Entity<ConsentLog>(entity =>
+        {
+            entity.HasOne(cl => cl.User)
+                  .WithMany()
+                  .HasForeignKey(cl => cl.UserId)
+                  .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(cl => cl.PrivacyPolicyVersion)
+                  .WithMany()
+                  .HasForeignKey(cl => cl.PrivacyPolicyVersionId)
+                  .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<User>(entity =>
+        {
+            entity.HasOne(u => u.ConsentVersion)
+                  .WithMany()
+                  .HasForeignKey(u => u.ConsentVersionId)
+                  .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.Entity<BankAuthorization>(entity =>

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -18,6 +18,7 @@ public class BankoDbContext : DbContext
     public DbSet<BankAccount> BankAccounts { get; set; }
     public DbSet<BankAuthorization> BankAuthorizations { get; set; }
     public DbSet<Pending> Pendings { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -72,6 +73,16 @@ public class BankoDbContext : DbContext
             .HasIndex(da => da.Iban); // Add a unique constraint for IBAN
 
         modelBuilder.Entity<User>().HasIndex(u => u.Email).IsUnique();
+
+        modelBuilder.Entity<RefreshToken>(entity =>
+        {
+            entity.HasIndex(rt => rt.Token).IsUnique();
+
+            entity.HasOne(rt => rt.User)
+                  .WithMany()
+                  .HasForeignKey(rt => rt.UserId)
+                  .OnDelete(DeleteBehavior.Cascade);
+        });
 
         modelBuilder.Entity<BankAuthorization>(entity =>
         {

--- a/BankoApi/Data/Dao/ConsentLog.cs
+++ b/BankoApi/Data/Dao/ConsentLog.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BankoApi.Data.Dao;
+
+[Table("ConsentLogs")]
+public class ConsentLog
+{
+    [Key] public Guid Id { get; set; }
+
+    [Required] public Guid UserId { get; set; }
+
+    [Required] public Guid PrivacyPolicyVersionId { get; set; }
+
+    [Required] public bool Accepted { get; set; }
+
+    [Required] public DateTime RecordedAt { get; set; } = DateTime.UtcNow;
+
+    [ForeignKey("UserId")]
+    public virtual User User { get; set; } = null!;
+
+    [ForeignKey("PrivacyPolicyVersionId")]
+    public virtual PrivacyPolicyVersion PrivacyPolicyVersion { get; set; } = null!;
+}

--- a/BankoApi/Data/Dao/PrivacyPolicyVersion.cs
+++ b/BankoApi/Data/Dao/PrivacyPolicyVersion.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BankoApi.Data.Dao;
+
+[Table("PrivacyPolicyVersions")]
+public class PrivacyPolicyVersion
+{
+    [Key] public Guid Id { get; set; }
+
+    [Required] public int Version { get; set; }
+
+    [Required] [StringLength(500)] public string Title { get; set; } = string.Empty;
+
+    [Required] public DateTime PublishedAt { get; set; } = DateTime.UtcNow;
+
+    [Required] public bool IsActive { get; set; } = true;
+}

--- a/BankoApi/Data/Dao/RefreshToken.cs
+++ b/BankoApi/Data/Dao/RefreshToken.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BankoApi.Data.Dao;
+
+[Table("RefreshTokens")]
+public class RefreshToken
+{
+    [Key] public Guid Id { get; set; }
+
+    [Required] public Guid UserId { get; set; }
+
+    [Required] [StringLength(512)] public string Token { get; set; } = string.Empty;
+
+    [Required] [StringLength(512)] public string JwtId { get; set; } = string.Empty;
+
+    [Required] public bool IsUsed { get; set; }
+
+    [Required] public bool IsRevoked { get; set; }
+
+    [Required] public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [Required] public DateTime ExpiresAt { get; set; }
+
+    [ForeignKey("UserId")]
+    public virtual User User { get; set; } = null!;
+}

--- a/BankoApi/Data/Dao/User.cs
+++ b/BankoApi/Data/Dao/User.cs
@@ -31,4 +31,9 @@ public class User
     [Required] public bool ConsentGiven { get; set; } = false;
 
     public DateTime? ConsentUpdatedAt { get; set; }
+
+    public Guid? ConsentVersionId { get; set; }
+
+    [ForeignKey("ConsentVersionId")]
+    public virtual PrivacyPolicyVersion? ConsentVersion { get; set; }
 }

--- a/BankoApi/Migrations/20260623110302_AddRefreshToken.Designer.cs
+++ b/BankoApi/Migrations/20260623110302_AddRefreshToken.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260623110302_AddRefreshToken")]
+    partial class AddRefreshToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260623110302_AddRefreshToken.cs
+++ b/BankoApi/Migrations/20260623110302_AddRefreshToken.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Token = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                    JwtId = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                    IsUsed = table.Column<bool>(type: "bit", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "UserId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_Token",
+                table: "RefreshTokens",
+                column: "Token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+        }
+    }
+}

--- a/BankoApi/Migrations/20260624081630_AddGDPRTables.Designer.cs
+++ b/BankoApi/Migrations/20260624081630_AddGDPRTables.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624081630_AddGDPRTables")]
+    partial class AddGDPRTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260624081630_AddGDPRTables.cs
+++ b/BankoApi/Migrations/20260624081630_AddGDPRTables.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGDPRTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ConsentVersionId",
+                table: "Users",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "PrivacyPolicyVersions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Version = table.Column<int>(type: "int", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    PublishedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PrivacyPolicyVersions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConsentLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PrivacyPolicyVersionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Accepted = table.Column<bool>(type: "bit", nullable: false),
+                    RecordedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConsentLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ConsentLogs_PrivacyPolicyVersions_PrivacyPolicyVersionId",
+                        column: x => x.PrivacyPolicyVersionId,
+                        principalTable: "PrivacyPolicyVersions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ConsentLogs_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "UserId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_ConsentVersionId",
+                table: "Users",
+                column: "ConsentVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConsentLogs_PrivacyPolicyVersionId",
+                table: "ConsentLogs",
+                column: "PrivacyPolicyVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConsentLogs_UserId",
+                table: "ConsentLogs",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PrivacyPolicyVersions_Version",
+                table: "PrivacyPolicyVersions",
+                column: "Version",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_PrivacyPolicyVersions_ConsentVersionId",
+                table: "Users",
+                column: "ConsentVersionId",
+                principalTable: "PrivacyPolicyVersions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_PrivacyPolicyVersions_ConsentVersionId",
+                table: "Users");
+
+            migrationBuilder.DropTable(
+                name: "ConsentLogs");
+
+            migrationBuilder.DropTable(
+                name: "PrivacyPolicyVersions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Users_ConsentVersionId",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ConsentVersionId",
+                table: "Users");
+        }
+    }
+}

--- a/BankoApi/Program.cs
+++ b/BankoApi/Program.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using BankoApi;
 using BankoApi.Controllers.GoCardless;
 using BankoApi.Data;
@@ -6,8 +7,10 @@ using BankoApi.Logging;
 using BankoApi.Repository;
 using BankoApi.Services;
 using DotNetEnv;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Console;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -33,6 +36,7 @@ builder.Services.AddControllers(options =>
     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
 
+builder.Services.AddScoped<TokenService>();
 builder.Services.AddScoped<BankAuthorizationRepository>();
 builder.Services.AddScoped<TransactionsRepository>();
 builder.Services.AddScoped<UserRepository>();
@@ -47,6 +51,30 @@ builder.Services.AddDbContext<BankoDbContext>(options =>
     var connectionString =
         $"Server={baseUrl},1433;Database={db};User Id={dbUser};Password={dbPassword};TrustServerCertificate=True;";
     options.UseLazyLoadingProxies().UseSqlServer(connectionString);
+});
+
+var jwtSecret = builder.Configuration["Jwt:Secret"]
+                ?? throw new Exception("JWT Secret is missing");
+var jwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "BankoApi";
+var jwtAudience = builder.Configuration["Jwt:Audience"] ?? "BankoMobile";
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = jwtIssuer,
+        ValidAudience = jwtAudience,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
+        ClockSkew = TimeSpan.Zero
+    };
 });
 
 var baseUrl = builder.Configuration["GoCardlessAPI:BaseUrl"] ?? throw new Exception("GoCadless Base URL is missing");
@@ -81,6 +109,7 @@ app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/BankoApi/Program.cs
+++ b/BankoApi/Program.cs
@@ -109,6 +109,8 @@ app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 
+app.UseStaticFiles();
+
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -61,7 +61,7 @@ public class TransactionsRepository
             
             if (!storedTransactions.Contains(newTransaction.InternalTransactionId) && !storedTransactions.Contains(newTransaction.TransactionId))
             {
-                if (newTransaction.TransactionId.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(newTransaction.TransactionId))
                 {
                     newTransaction.TransactionId = Guid.NewGuid().ToString();
                 }

--- a/BankoApi/Repository/UserRepository.cs
+++ b/BankoApi/Repository/UserRepository.cs
@@ -60,6 +60,46 @@ public class UserRepository
         return user!.UserId;
     }
 
+    public void UpdatePassword(BankoDbContext context, Guid userId, string currentPassword, string newPassword)
+    {
+        var user = context.Users.Find(userId)
+            ?? throw new EmailNotFoundException($"User {userId} not found");
+
+        if (!VerifyPassword(currentPassword, user.PasswordHash))
+            throw new PasswordNotFoundException("Current password is incorrect");
+
+        user.PasswordHash = HashPassword(newPassword);
+        user.UpdatedAt = DateTime.UtcNow;
+        context.SaveChanges();
+    }
+
+    public void SoftDeleteUser(BankoDbContext context, Guid userId)
+    {
+        var user = context.Users.Find(userId)
+            ?? throw new EmailNotFoundException($"User {userId} not found");
+
+        user.Email = $"deleted-{userId:N}@anon.banko";
+        user.FullName = null;
+        user.PhoneNumber = null;
+        user.Address = null;
+        user.PasswordHash = null;
+        user.IsActive = false;
+        user.DeletedAt = DateTime.UtcNow;
+        user.UpdatedAt = DateTime.UtcNow;
+        user.ConsentGiven = false;
+        user.ConsentUpdatedAt = null;
+        user.ConsentVersionId = null;
+
+        var activeTokens = context.RefreshTokens
+            .Where(rt => rt.UserId == userId && !rt.IsRevoked);
+        foreach (var token in activeTokens)
+        {
+            token.IsRevoked = true;
+        }
+
+        context.SaveChanges();
+    }
+
     private string HashPassword(string password)
     {
         return BCrypt.Net.BCrypt.EnhancedHashPassword(password, WorkFactor);

--- a/BankoApi/Services/Model/Transactions.cs
+++ b/BankoApi/Services/Model/Transactions.cs
@@ -99,7 +99,7 @@ public static class TransactionsExtensions
         return transactions.BankTransactions.Booked.ConvertAll(bookedTransaction =>
             new TransactionDao
             {
-                Id = bookedTransaction.TransactionId,
+                Id = bookedTransaction.TransactionId!,
                 UserId = userId,
                 BankAccountId = bankAccountId,
                 BookingDate = DateTime.Parse(bookedTransaction.BookingDate),

--- a/BankoApi/Services/ScheduledTaskService.cs
+++ b/BankoApi/Services/ScheduledTaskService.cs
@@ -57,7 +57,7 @@ public class ScheduledTaskService : BackgroundService
                 .Select(y => y.BankAccountId)
                 .ToListAsync();
 
-            if (!bankAccountIds.IsNullOrEmpty())
+            if (bankAccountIds.Count != 0)
             {
                 foreach (var gcAccountId in bankAccountIds)
                 {

--- a/BankoApi/Services/TokenService.cs
+++ b/BankoApi/Services/TokenService.cs
@@ -1,0 +1,159 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using BankoApi.Data;
+using BankoApi.Data.Dao;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+
+namespace BankoApi.Services;
+
+public class TokenService
+{
+    private readonly IConfiguration _configuration;
+    private readonly BankoDbContext _context;
+
+    public TokenService(IConfiguration configuration, BankoDbContext context)
+    {
+        _configuration = configuration;
+        _context = context;
+    }
+
+    public virtual (string accessToken, string refreshToken, long expiresIn) GenerateTokens(User user)
+    {
+        var accessToken = GenerateAccessToken(user);
+        var refreshToken = GenerateRefreshToken();
+        var expiresIn = GetAccessTokenExpirationMinutes() * 60L;
+
+        var refreshTokenEntity = new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.UserId,
+            Token = refreshToken,
+            JwtId = GetJwtId(accessToken),
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(GetRefreshTokenExpirationDays()),
+            IsUsed = false,
+            IsRevoked = false
+        };
+
+        _context.RefreshTokens.Add(refreshTokenEntity);
+        _context.SaveChanges();
+
+        return (accessToken, refreshToken, expiresIn);
+    }
+
+    public async Task<(Guid userId, string accessToken, string refreshToken, long expiresIn)> RefreshTokenAsync(string oldRefreshToken)
+    {
+        var storedToken = await _context.RefreshTokens
+            .Include(rt => rt.User)
+            .FirstOrDefaultAsync(rt => rt.Token == oldRefreshToken);
+
+        if (storedToken == null)
+            throw new SecurityTokenException("Refresh token not found");
+
+        if (storedToken.IsRevoked)
+            throw new SecurityTokenException("Refresh token is revoked");
+
+        if (storedToken.IsUsed)
+        {
+            RevokeUserTokens(storedToken.UserId);
+            throw new SecurityTokenException("Refresh token is already used — possible token reuse detected");
+        }
+
+        if (storedToken.ExpiresAt < DateTime.UtcNow)
+            throw new SecurityTokenException("Refresh token has expired");
+
+        storedToken.IsUsed = true;
+        _context.RefreshTokens.Update(storedToken);
+        await _context.SaveChangesAsync();
+
+        var (accessToken, newRefreshToken, expiresIn) = GenerateTokens(storedToken.User);
+        return (storedToken.UserId, accessToken, newRefreshToken, expiresIn);
+    }
+
+    public async Task RevokeRefreshTokenAsync(string refreshToken)
+    {
+        var storedToken = await _context.RefreshTokens
+            .FirstOrDefaultAsync(rt => rt.Token == refreshToken);
+
+        if (storedToken != null)
+        {
+            storedToken.IsRevoked = true;
+            _context.RefreshTokens.Update(storedToken);
+            await _context.SaveChangesAsync();
+        }
+    }
+
+    private string GenerateAccessToken(User user)
+    {
+        var secret = _configuration["Jwt:Secret"]
+                     ?? throw new InvalidOperationException("JWT Secret is not configured");
+        var issuer = _configuration["Jwt:Issuer"] ?? "BankoApi";
+        var audience = _configuration["Jwt:Audience"] ?? "BankoMobile";
+        var expirationMinutes = GetAccessTokenExpirationMinutes();
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.UserId.ToString()),
+            new Claim(ClaimTypes.Email, user.Email),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: issuer,
+            audience: audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(expirationMinutes),
+            signingCredentials: credentials
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static string GenerateRefreshToken()
+    {
+        var randomBytes = new byte[64];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(randomBytes);
+        return Convert.ToBase64String(randomBytes);
+    }
+
+    private static string GetJwtId(string accessToken)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(accessToken);
+        return jwt.Id;
+    }
+
+    private int GetAccessTokenExpirationMinutes()
+    {
+        return int.TryParse(_configuration["Jwt:AccessTokenExpirationMinutes"], out var minutes)
+            ? minutes
+            : 15;
+    }
+
+    private int GetRefreshTokenExpirationDays()
+    {
+        return int.TryParse(_configuration["Jwt:RefreshTokenExpirationDays"], out var days)
+            ? days
+            : 7;
+    }
+
+    private void RevokeUserTokens(Guid userId)
+    {
+        var activeTokens = _context.RefreshTokens
+            .Where(rt => rt.UserId == userId && !rt.IsRevoked);
+        
+        foreach (var token in activeTokens)
+        {
+            token.IsRevoked = true;
+        }
+        
+        _context.SaveChanges();
+    }
+}

--- a/BankoApi/Utils.cs
+++ b/BankoApi/Utils.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+
 namespace BankoApi;
 
 public class Utils
@@ -18,5 +20,15 @@ public class Utils
         // Use Dev database connection string (can be from configuration or a default)
         return builder.Configuration["GoogleCloud:DevDb"] ??
                throw new Exception("Missing environment variable: GoogleCloud:DevDb");
+    }
+}
+
+public static class ClaimsPrincipalExtensions
+{
+    public static Guid GetUserId(this ClaimsPrincipal user)
+    {
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? throw new UnauthorizedAccessException("User ID not found in token");
+        return Guid.Parse(claim);
     }
 }

--- a/BankoApi/appsettings.json
+++ b/BankoApi/appsettings.json
@@ -14,5 +14,12 @@
     "DevDb": "BankoDb_Dev",
     "Prod": "BankoDb"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Secret": "ThisIsADevelopmentSecretKeyThatIsAtLeast32BytesLong!",
+    "Issuer": "BankoApi",
+    "Audience": "BankoMobile",
+    "AccessTokenExpirationMinutes": 15,
+    "RefreshTokenExpirationDays": 7
+  }
 }

--- a/BankoApi/wwwroot/privacy-policy-v1.html
+++ b/BankoApi/wwwroot/privacy-policy-v1.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy v1</title>
+</head>
+<body>
+  <h1>Privacy Policy Version 1</h1>
+  <p><em>Placeholder</em> — Replace with actual privacy policy content.</p>
+  <p>Published: June 2026</p>
+</body>
+</html>


### PR DESCRIPTION
## What

- Add GDPR DTOs and API methods to the mobile client
- Implement GDPR user controls in ProfileViewModel and ProfileScreen
- Add comprehensive test coverage for auth and GDPR flows
- Rename `BankoApiService.kt.kt` to `BankoApiService.kt`

## Why

- Enable users to view/update their profile, re-accept the privacy policy, export their personal data, and delete their account directly from the mobile app
- Provide a complete user-facing UI with export dialog, delete confirmation dialog, consent re-accept button, loading indicator, and error state handling
- Ensure correctness of all auth and GDPR operations with 48 new unit tests across SessionManager, AuthRepository, LoginViewModel, ProfileViewModel, and BankoApiService (206/206 passing)
- Remove the misleading double `.kt` file extension that could cause confusion during builds and code reviews