### PR TITLE
Fix Microsoft.OpenApi version conflict

### DIFF
--- a/BankoApi/BankoApi.csproj
+++ b/BankoApi/BankoApi.csproj
@@ -10,7 +10,6 @@
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="DotNetEnv" Version="3.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.10" />


### PR DESCRIPTION
PR description (create it with the link above):

## What
- Remove `Microsoft.AspNetCore.OpenApi` package reference from `BankoApi.csproj`
- Change `using Microsoft.OpenApi` to `using Microsoft.OpenApi.Models` in `Program.cs`

## Why
`Microsoft.AspNetCore.OpenApi` 9.0.0 transitively depends on `Microsoft.OpenApi` 1.x, while `Swashbuckle.AspNetCore` 10.2.3 requires `Microsoft.OpenApi` 2.x. At runtime both assemblies load, but the v1 assembly is missing types that moved or were removed in v2, causing a `ReflectionTypeLoadException` that crashes `Program.cs:117` (`MapControllers`). Since OpenAPI/Swagger is handled entirely via Swashbuckle, `Microsoft.AspNetCore.OpenApi` is unused and can be safely removed.