### PR TITLE
fix: increase refresh token expiry from 7 to 30 days

### DIFF
--- a/BankoApi/appsettings.json
+++ b/BankoApi/appsettings.json
@@ -20,6 +20,6 @@
     "Issuer": "BankoApi",
     "Audience": "BankoMobile",
     "AccessTokenExpirationMinutes": 15,
-    "RefreshTokenExpirationDays": 7
+    "RefreshTokenExpirationDays": 30
   }
 }


### PR DESCRIPTION
## What
- Increase RefreshTokenExpirationDays from 7 to 30

## Why
- 7 days was overly aggressive for a mobile app where re-authentication is high-friction; 30 days aligns with OWASP guidance for rotated, revocable refresh tokens and gives users a reasonable window between app uses