### PR TITLE
Feature/institution logo and bank info

### DIFF
--- a/BankoApi.Tests/Controllers/SettingsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/SettingsControllerTests.cs
@@ -502,6 +502,29 @@ public class SettingsControllerTests
                     new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
             });
 
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("institutions/TEST_BANK/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "TEST_BANK",
+                        name = "Test Bank",
+                        bic = "TESTBIC22",
+                        transaction_total_days = "180",
+                        countries = new[] { "GB" },
+                        logo = "https://example.com/logo.png",
+                        max_access_valid_for_days = "90"
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         var controller = new SettingsController(service, ctx, new BankAuthorizationRepository(), Mock.Of<ILogger<SettingsController>>());
         var request = new UpsertEndUserAgreementRequest
@@ -580,6 +603,29 @@ public class SettingsControllerTests
                         ssn = "",
                         account_selection = false,
                         redirect_immediate = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("institutions/TEST_BANK/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "TEST_BANK",
+                        name = "Test Bank",
+                        bic = "TESTBIC22",
+                        transaction_total_days = "180",
+                        countries = new[] { "GB" },
+                        logo = "https://example.com/logo.png",
+                        max_access_valid_for_days = "90"
                     },
                     new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
             });

--- a/BankoApi/Controllers/Settings/BankAuthorizationController.cs
+++ b/BankoApi/Controllers/Settings/BankAuthorizationController.cs
@@ -6,6 +6,7 @@ using BankoApi.Controllers.GoCardless.Responses;
 using BankoApi.Data.Dao;
 using BankoApi.Exceptions.Settings;
 using BankoApi.Services.Model;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -107,19 +108,46 @@ namespace BankoApi.Controllers.Settings
             var eua = await _goCardlessService.GetEndUserAgreement();
             EndUserAgreement? validEua = _repository.HasValidNonAcceptedAgreement(eua);
 
+            string institutionId;
             if (validEua == null)
             {
                 if (request.InstitutionId != null && request.DaysOfAccess != null)
                 {
-                    validEua = await _goCardlessService.CreateEndUserAgreement(institutionId: request.InstitutionId, daysOfAccess: request.DaysOfAccess.Value);
+                    institutionId = request.InstitutionId;
+                    validEua = await _goCardlessService.CreateEndUserAgreement(institutionId: institutionId, daysOfAccess: request.DaysOfAccess.Value);
                 }
                 else
                 {
-                    String institutionId = "BIEN_SPAREBANK_BIENNOK1"; // TODO: prendere l'insitutionId dal DB
-                    int daysOfAccess = eua.Results.Where(e => e.InstitutionId == institutionId).First().AccessValidForDays;
-
-                    validEua = await _goCardlessService.CreateEndUserAgreement(institutionId: institutionId, daysOfAccess: daysOfAccess);
+                    return BadRequest("InstitutionId is required to create a new agreement");
                 }
+            }
+            else
+            {
+                institutionId = validEua.InstitutionId;
+            }
+
+            // Fetch and store institution data
+            var gcInstitution = await _goCardlessService.GetInstitutionAsync(institutionId);
+            if (gcInstitution != null)
+            {
+                var existing = await _dbContext.Institutions.FindAsync(gcInstitution.Id);
+                if (existing == null)
+                {
+                    _dbContext.Institutions.Add(new Institution
+                    {
+                        Id = gcInstitution.Id,
+                        Name = gcInstitution.Name,
+                        LogoUrl = gcInstitution.Logo
+                    });
+                }
+                else
+                {
+                    existing.Name = gcInstitution.Name;
+                    existing.LogoUrl = gcInstitution.Logo;
+                    existing.UpdatedAt = DateTime.UtcNow;
+                }
+
+                await _dbContext.SaveChangesAsync();
             }
 
             var requisition = await _goCardlessService.CreateRequisition(
@@ -137,6 +165,39 @@ namespace BankoApi.Controllers.Settings
                 RequisitionId = requisition.Id,
                 ReferenceId = requisition.Reference
             });
+        }
+
+        [AllowAnonymous]
+        [HttpGet("institutions")]
+        public async Task<IActionResult> GetInstitutions([FromQuery] string? country = null)
+        {
+            var institutions = await _goCardlessService.GetInstitutionsAsync(country);
+            return Ok(institutions);
+        }
+
+        [HttpPost("institutions/sync-logos")]
+        public async Task<IActionResult> SyncMissingLogos()
+        {
+            var missing = await _dbContext.Institutions
+                .Where(i => i.LogoUrl == null || i.LogoUrl == "")
+                .ToListAsync();
+
+            var updated = 0;
+            foreach (var institution in missing)
+            {
+                var gcInstitution = await _goCardlessService.GetInstitutionAsync(institution.Id);
+                if (gcInstitution?.Logo != null)
+                {
+                    institution.LogoUrl = gcInstitution.Logo;
+                    institution.UpdatedAt = DateTime.UtcNow;
+                    updated++;
+                }
+            }
+
+            if (updated > 0)
+                await _dbContext.SaveChangesAsync();
+
+            return Ok(new { total = missing.Count, updated });
         }
     }
 }

--- a/BankoApi/Controllers/Transactions/TransactionsController.cs
+++ b/BankoApi/Controllers/Transactions/TransactionsController.cs
@@ -1,6 +1,7 @@
 using BankoApi.Controllers.Settings.Requests;
 using BankoApi.Controllers.Transactions.Requests;
 using BankoApi.Data;
+using BankoApi.Data.Dao;
 using BankoApi.Services.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -60,12 +61,41 @@ public class TransactionsController : ControllerBase
             .Include(t => t.DebtorAccount)
             .Include(t => t.CreditorAccount)
             .Include(t => t.ExpenseTag)
+            .Include(t => t.BankAccount)
+                .ThenInclude(ba => ba.BankAuthorization)
+                    .ThenInclude(ba => ba.Institution)
             .OrderByDescending(t => t.BookingDate)
             .ToListAsync();
 
+        var response = transactions.ConvertAll(t => new TransactionResponse
+        {
+            Id = t.Id,
+            UserId = t.UserId,
+            BankAccountId = t.BankAccountId,
+            BookingDate = t.BookingDate,
+            ValueDate = t.ValueDate,
+            Amount = t.Amount,
+            Currency = t.Currency,
+            DebtorAccount = t.DebtorAccount,
+            RemittanceInformationUnstructured = t.RemittanceInformationUnstructured,
+            RemittanceInformationUnstructuredArray = t.RemittanceInformationUnstructuredArray,
+            BankTransactionCode = t.BankTransactionCode,
+            InternalTransactionId = t.InternalTransactionId,
+            CreditorName = t.CreditorName,
+            CreditorAccount = t.CreditorAccount,
+            DebtorName = t.DebtorName,
+            RemittanceInformationStructuredArray = t.RemittanceInformationStructuredArray,
+            ExpenseTagId = t.ExpenseTagId,
+            Note = t.Note,
+            isDeleted = t.isDeleted,
+            ExpenseTag = t.ExpenseTag,
+            BankName = t.BankAccount?.BankAuthorization?.Institution?.Name,
+            BankLogoUrl = t.BankAccount?.BankAuthorization?.Institution?.LogoUrl
+        });
+
         return Ok(new PaginatedTransactionResponse
         {
-            Transactions = transactions,
+            Transactions = response,
             TotalCount = totalCount,
             PageNumber = pageNumber,
             PageSize = pageSize

--- a/BankoApi/Controllers/Transactions/TransactionsController.cs
+++ b/BankoApi/Controllers/Transactions/TransactionsController.cs
@@ -35,7 +35,9 @@ public class TransactionsController : ControllerBase
             return BadRequest("The fromDate cannot be greater than toDate.");
 
         toDate ??= DateTime.UtcNow;
-        fromDate ??= _dbContext.Transactions.Min(t => t.BookingDate);
+        fromDate ??= await _dbContext.Transactions
+            .DefaultIfEmpty()
+            .MinAsync(t => (DateTime?)t.BookingDate) ?? DateTime.UtcNow.AddYears(-1);
 
         var skip = (pageNumber - 1) * pageSize;
 
@@ -61,11 +63,21 @@ public class TransactionsController : ControllerBase
             .Include(t => t.DebtorAccount)
             .Include(t => t.CreditorAccount)
             .Include(t => t.ExpenseTag)
-            .Include(t => t.BankAccount)
-                .ThenInclude(ba => ba.BankAuthorization)
-                    .ThenInclude(ba => ba.Institution)
             .OrderByDescending(t => t.BookingDate)
             .ToListAsync();
+
+        // Manual join: look up BankAccount by matching BankAccountId (GC UUID string)
+        // instead of relying on a DB FK that maps Transaction.BankAccountId to BankAccounts.Id
+        var gcAccountIds = transactions
+            .Select(t => t.BankAccountId.ToString())
+            .Distinct()
+            .ToList();
+        var bankAccounts = await _dbContext.BankAccounts
+            .Where(ba => gcAccountIds.Contains(ba.BankAccountId))
+            .Include(ba => ba.BankAuthorization)
+                .ThenInclude(ba => ba.Institution)
+            .ToListAsync();
+        var bankAccountLookup = bankAccounts.ToDictionary(ba => Guid.Parse(ba.BankAccountId));
 
         var response = transactions.ConvertAll(t => new TransactionResponse
         {
@@ -89,8 +101,8 @@ public class TransactionsController : ControllerBase
             Note = t.Note,
             isDeleted = t.isDeleted,
             ExpenseTag = t.ExpenseTag,
-            BankName = t.BankAccount?.BankAuthorization?.Institution?.Name,
-            BankLogoUrl = t.BankAccount?.BankAuthorization?.Institution?.LogoUrl
+            BankName = bankAccountLookup.GetValueOrDefault(t.BankAccountId)?.BankAuthorization?.Institution?.Name,
+            BankLogoUrl = bankAccountLookup.GetValueOrDefault(t.BankAccountId)?.BankAuthorization?.Institution?.LogoUrl
         });
 
         return Ok(new PaginatedTransactionResponse

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -169,12 +169,6 @@ public class BankoDbContext : DbContext
             entity.Property(e => e.Name).HasMaxLength(255);
         });
 
-        modelBuilder.Entity<Transaction>(entity =>
-        {
-            entity.HasOne(e => e.BankAccount)
-                  .WithMany()
-                  .HasForeignKey(e => e.BankAccountId)
-                  .OnDelete(DeleteBehavior.Restrict);
-        });
+
     }
 }

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -21,6 +21,7 @@ public class BankoDbContext : DbContext
     public DbSet<RefreshToken> RefreshTokens { get; set; }
     public DbSet<PrivacyPolicyVersion> PrivacyPolicyVersions { get; set; }
     public DbSet<ConsentLog> ConsentLogs { get; set; }
+    public DbSet<Institution> Institutions { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -132,6 +133,12 @@ public class BankoDbContext : DbContext
                   .HasForeignKey(e => e.UserId)
                   .OnDelete(DeleteBehavior.Cascade);
 
+            // Define the relationship with Institution
+            entity.HasOne(e => e.Institution)
+                  .WithMany()
+                  .HasForeignKey(e => e.InstitutionId)
+                  .OnDelete(DeleteBehavior.SetNull);
+
             entity.Property(e => e.Status)
             .HasConversion<string>()  // This converts enum to string
             .HasMaxLength(50);
@@ -153,6 +160,21 @@ public class BankoDbContext : DbContext
                   .WithMany(c => c.BankAccounts)
                   .HasForeignKey(e => e.BankAuthorizationId)
                   .OnDelete(DeleteBehavior.Cascade); // ON DELETE CASCADE
+        });
+
+        modelBuilder.Entity<Institution>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasMaxLength(50);
+            entity.Property(e => e.Name).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<Transaction>(entity =>
+        {
+            entity.HasOne(e => e.BankAccount)
+                  .WithMany()
+                  .HasForeignKey(e => e.BankAccountId)
+                  .OnDelete(DeleteBehavior.Restrict);
         });
     }
 }

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -165,7 +165,7 @@ public class BankoDbContext : DbContext
         modelBuilder.Entity<Institution>(entity =>
         {
             entity.HasKey(e => e.Id);
-            entity.Property(e => e.Id).HasMaxLength(50);
+            entity.Property(e => e.Id).HasMaxLength(100);
             entity.Property(e => e.Name).HasMaxLength(255);
         });
 

--- a/BankoApi/Data/Dao/BankAuthorization.cs
+++ b/BankoApi/Data/Dao/BankAuthorization.cs
@@ -38,6 +38,7 @@ public class BankAuthorization
     public virtual User User { get; set; }
     [ForeignKey("BankAccountId")]
     public virtual ICollection<BankAccount>? BankAccounts { get; set; }
+    public virtual Institution? Institution { get; set; }
 }
 
 public enum BankAuthorizationStaus

--- a/BankoApi/Data/Dao/Institution.cs
+++ b/BankoApi/Data/Dao/Institution.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BankoApi.Data.Dao;
+
+public class Institution
+{
+    [Key]
+    [MaxLength(50)]
+    public required string Id { get; set; }
+
+    [MaxLength(255)]
+    public required string Name { get; set; }
+
+    public string? LogoUrl { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/BankoApi/Data/Dao/Institution.cs
+++ b/BankoApi/Data/Dao/Institution.cs
@@ -5,7 +5,7 @@ namespace BankoApi.Data.Dao;
 public class Institution
 {
     [Key]
-    [MaxLength(50)]
+    [MaxLength(100)]
     public required string Id { get; set; }
 
     [MaxLength(255)]

--- a/BankoApi/Data/Dao/Transaction.cs
+++ b/BankoApi/Data/Dao/Transaction.cs
@@ -27,7 +27,6 @@ public class Transaction
     public string? Note { get; set; }
     public bool isDeleted { get; set; }
     public virtual ExpenseTag? ExpenseTag { get; set; }
-    public virtual BankAccount? BankAccount { get; set; }
 }
 
 public class CreditorAccount

--- a/BankoApi/Migrations/20260709094003_AddInstitutionsTable.Designer.cs
+++ b/BankoApi/Migrations/20260709094003_AddInstitutionsTable.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709094003_AddInstitutionsTable")]
+    partial class AddInstitutionsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260709094003_AddInstitutionsTable.Designer.cs
+++ b/BankoApi/Migrations/20260709094003_AddInstitutionsTable.Designer.cs
@@ -448,8 +448,6 @@ namespace BankoApi.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BankAccountId");
-
                     b.HasIndex("CreditorAccountId");
 
                     b.HasIndex("DebtorAccountId");
@@ -581,12 +579,6 @@ namespace BankoApi.Migrations
 
             modelBuilder.Entity("BankoApi.Data.Dao.Transaction", b =>
                 {
-                    b.HasOne("BankoApi.Data.Dao.BankAccount", "BankAccount")
-                        .WithMany()
-                        .HasForeignKey("BankAccountId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.HasOne("BankoApi.Data.Dao.CreditorAccount", "CreditorAccount")
                         .WithMany()
                         .HasForeignKey("CreditorAccountId")
@@ -601,8 +593,6 @@ namespace BankoApi.Migrations
                         .WithMany()
                         .HasForeignKey("ExpenseTagId")
                         .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("BankAccount");
 
                     b.Navigation("CreditorAccount");
 

--- a/BankoApi/Migrations/20260709094003_AddInstitutionsTable.cs
+++ b/BankoApi/Migrations/20260709094003_AddInstitutionsTable.cs
@@ -23,10 +23,6 @@ namespace BankoApi.Migrations
                     DROP INDEX [IX_Transactions_BankAccountId] ON [Transactions];
                 IF OBJECT_ID('Institutions') IS NOT NULL
                     DROP TABLE [Institutions];
-                -- Remove orphaned transactions before creating FK
-                DELETE FROM [Transactions]
-                WHERE [BankAccountId] IS NOT NULL
-                  AND NOT EXISTS (SELECT 1 FROM [BankAccounts] WHERE [Id] = [Transactions].[BankAccountId]);
             """);
 
             migrationBuilder.CreateTable(
@@ -43,11 +39,6 @@ namespace BankoApi.Migrations
                 {
                     table.PrimaryKey("PK_Institutions", x => x.Id);
                 });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Transactions_BankAccountId",
-                table: "Transactions",
-                column: "BankAccountId");
 
             // Seed data from existing BankAuthorizations
             migrationBuilder.Sql(@"
@@ -74,33 +65,27 @@ namespace BankoApi.Migrations
                 principalTable: "Institutions",
                 principalColumn: "Id",
                 onDelete: ReferentialAction.SetNull);
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_Transactions_BankAccounts_BankAccountId",
-                table: "Transactions",
-                column: "BankAccountId",
-                principalTable: "BankAccounts",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Restrict);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Cleanup objects that may exist from a previous version of this migration
+            // (the FK and index on Transactions.BankAccountId were added originally
+            //  but later removed — still need to drop them on rollback if present)
+            migrationBuilder.Sql("""
+                IF OBJECT_ID('FK_Transactions_BankAccounts_BankAccountId') IS NOT NULL
+                    ALTER TABLE [Transactions] DROP CONSTRAINT [FK_Transactions_BankAccounts_BankAccountId];
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_Transactions_BankAccountId' AND object_id = OBJECT_ID('Transactions'))
+                    DROP INDEX [IX_Transactions_BankAccountId] ON [Transactions];
+            """);
+
             migrationBuilder.DropForeignKey(
                 name: "FK_BankAuthorizations_Institutions_InstitutionId",
                 table: "BankAuthorizations");
 
-            migrationBuilder.DropForeignKey(
-                name: "FK_Transactions_BankAccounts_BankAccountId",
-                table: "Transactions");
-
             migrationBuilder.DropTable(
                 name: "Institutions");
-
-            migrationBuilder.DropIndex(
-                name: "IX_Transactions_BankAccountId",
-                table: "Transactions");
 
             migrationBuilder.DropIndex(
                 name: "IX_BankAuthorizations_InstitutionId",

--- a/BankoApi/Migrations/20260709094003_AddInstitutionsTable.cs
+++ b/BankoApi/Migrations/20260709094003_AddInstitutionsTable.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstitutionsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Institutions",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    LogoUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Institutions", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Transactions_BankAccountId",
+                table: "Transactions",
+                column: "BankAccountId");
+
+            // Seed data from existing BankAuthorizations
+            migrationBuilder.Sql(@"
+                INSERT INTO [Institutions] ([Id], [Name], [CreatedAt], [UpdatedAt])
+                SELECT DISTINCT
+                    [ba].[InstitutionId],
+                    COALESCE([ba].[InstitutionName], [ba].[InstitutionId]),
+                    GETUTCDATE(),
+                    GETUTCDATE()
+                FROM [BankAuthorizations] [ba]
+                WHERE [ba].[InstitutionId] IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM [Institutions] [i] WHERE [i].[Id] = [ba].[InstitutionId])
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BankAuthorizations_InstitutionId",
+                table: "BankAuthorizations",
+                column: "InstitutionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BankAuthorizations_Institutions_InstitutionId",
+                table: "BankAuthorizations",
+                column: "InstitutionId",
+                principalTable: "Institutions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Transactions_BankAccounts_BankAccountId",
+                table: "Transactions",
+                column: "BankAccountId",
+                principalTable: "BankAccounts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_BankAuthorizations_Institutions_InstitutionId",
+                table: "BankAuthorizations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Transactions_BankAccounts_BankAccountId",
+                table: "Transactions");
+
+            migrationBuilder.DropTable(
+                name: "Institutions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Transactions_BankAccountId",
+                table: "Transactions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BankAuthorizations_InstitutionId",
+                table: "BankAuthorizations");
+        }
+    }
+}

--- a/BankoApi/Migrations/20260709094003_AddInstitutionsTable.cs
+++ b/BankoApi/Migrations/20260709094003_AddInstitutionsTable.cs
@@ -11,11 +11,29 @@ namespace BankoApi.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Cleanup partial state from previous failed attempt & orphaned data
+            migrationBuilder.Sql("""
+                IF OBJECT_ID('FK_BankAuthorizations_Institutions_InstitutionId') IS NOT NULL
+                    ALTER TABLE [BankAuthorizations] DROP CONSTRAINT [FK_BankAuthorizations_Institutions_InstitutionId];
+                IF OBJECT_ID('FK_Transactions_BankAccounts_BankAccountId') IS NOT NULL
+                    ALTER TABLE [Transactions] DROP CONSTRAINT [FK_Transactions_BankAccounts_BankAccountId];
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_BankAuthorizations_InstitutionId' AND object_id = OBJECT_ID('BankAuthorizations'))
+                    DROP INDEX [IX_BankAuthorizations_InstitutionId] ON [BankAuthorizations];
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_Transactions_BankAccountId' AND object_id = OBJECT_ID('Transactions'))
+                    DROP INDEX [IX_Transactions_BankAccountId] ON [Transactions];
+                IF OBJECT_ID('Institutions') IS NOT NULL
+                    DROP TABLE [Institutions];
+                -- Remove orphaned transactions before creating FK
+                DELETE FROM [Transactions]
+                WHERE [BankAccountId] IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM [BankAccounts] WHERE [Id] = [Transactions].[BankAccountId]);
+            """);
+
             migrationBuilder.CreateTable(
                 name: "Institutions",
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Id = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
                     Name = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LogoUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),

--- a/BankoApi/Migrations/BankoDbContextModelSnapshot.cs
+++ b/BankoApi/Migrations/BankoDbContextModelSnapshot.cs
@@ -445,8 +445,6 @@ namespace BankoApi.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BankAccountId");
-
                     b.HasIndex("CreditorAccountId");
 
                     b.HasIndex("DebtorAccountId");
@@ -578,12 +576,6 @@ namespace BankoApi.Migrations
 
             modelBuilder.Entity("BankoApi.Data.Dao.Transaction", b =>
                 {
-                    b.HasOne("BankoApi.Data.Dao.BankAccount", "BankAccount")
-                        .WithMany()
-                        .HasForeignKey("BankAccountId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.HasOne("BankoApi.Data.Dao.CreditorAccount", "CreditorAccount")
                         .WithMany()
                         .HasForeignKey("CreditorAccountId")
@@ -598,8 +590,6 @@ namespace BankoApi.Migrations
                         .WithMany()
                         .HasForeignKey("ExpenseTagId")
                         .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("BankAccount");
 
                     b.Navigation("CreditorAccount");
 

--- a/BankoApi/Migrations/BankoDbContextModelSnapshot.cs
+++ b/BankoApi/Migrations/BankoDbContextModelSnapshot.cs
@@ -258,8 +258,8 @@ namespace BankoApi.Migrations
             modelBuilder.Entity("BankoApi.Data.Dao.Institution", b =>
                 {
                     b.Property<string>("Id")
-                        .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/BankoApi/Services/GoCardlessService.cs
+++ b/BankoApi/Services/GoCardlessService.cs
@@ -78,6 +78,31 @@ public class GoCardlessService
         return response.Content.ReadFromJsonAsync<EndUserAgreement>().Result;
     }
 
+    public async Task<GoCardlessInstitution?> GetInstitutionAsync(string institutionId)
+    {
+        var token = await _tokenService.GetAccessTokenAsync();
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _httpClient.GetAsync($"institutions/{institutionId}/");
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<GoCardlessInstitution>();
+    }
+
+    public async Task<List<GoCardlessInstitution>> GetInstitutionsAsync(string? countryCode = null)
+    {
+        var token = await _tokenService.GetAccessTokenAsync();
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var url = countryCode != null ? $"institutions/?country={countryCode}" : "institutions/";
+        var response = await _httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<List<GoCardlessInstitution>>() ?? new List<GoCardlessInstitution>();
+    }
+
     public async Task<Model.Requisition> CreateRequisition(string institutionId, string agreementId)
     {
 

--- a/BankoApi/Services/Model/GoCardlessInstitution.cs
+++ b/BankoApi/Services/Model/GoCardlessInstitution.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace BankoApi.Services.Model;
+
+public class GoCardlessInstitution
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("bic")]
+    public string Bic { get; set; } = string.Empty;
+
+    [JsonPropertyName("transaction_total_days")]
+    public string TransactionTotalDays { get; set; } = string.Empty;
+
+    [JsonPropertyName("countries")]
+    public List<string> Countries { get; set; } = new();
+
+    [JsonPropertyName("logo")]
+    public string Logo { get; set; } = string.Empty;
+
+    [JsonPropertyName("max_access_valid_for_days")]
+    public string MaxAccessValidForDays { get; set; } = string.Empty;
+}

--- a/BankoApi/Services/Model/PaginatedTransactionResponse.cs
+++ b/BankoApi/Services/Model/PaginatedTransactionResponse.cs
@@ -1,10 +1,8 @@
-using BankoApi.Data.Dao;
-
 namespace BankoApi.Services.Model;
 
 public class PaginatedTransactionResponse
 {
-    public required List<Transaction> Transactions { get; set; }
+    public required List<TransactionResponse> Transactions { get; set; }
     public int TotalCount { get; set; }
     public int PageNumber { get; set; }
     public int PageSize { get; set; }

--- a/BankoApi/Services/Model/TransactionResponse.cs
+++ b/BankoApi/Services/Model/TransactionResponse.cs
@@ -1,8 +1,8 @@
 using System.Text.Json.Serialization;
 
-namespace BankoApi.Data.Dao;
+namespace BankoApi.Services.Model;
 
-public class Transaction
+public class TransactionResponse
 {
     public required string Id { get; set; }
     public Guid UserId { get; set; }
@@ -13,36 +13,22 @@ public class Transaction
     public required string Currency { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public virtual DebtorAccount? DebtorAccount { get; set; }
+    public BankoApi.Data.Dao.DebtorAccount? DebtorAccount { get; set; }
 
     public required string RemittanceInformationUnstructured { get; set; }
     public required List<string> RemittanceInformationUnstructuredArray { get; set; }
     public string? BankTransactionCode { get; set; }
     public required string InternalTransactionId { get; set; }
     public string? CreditorName { get; set; }
-    public virtual CreditorAccount? CreditorAccount { get; set; }
+    public BankoApi.Data.Dao.CreditorAccount? CreditorAccount { get; set; }
     public string? DebtorName { get; set; }
     public List<string>? RemittanceInformationStructuredArray { get; set; }
     public string? ExpenseTagId { get; set; }
     public string? Note { get; set; }
     public bool isDeleted { get; set; }
-    public virtual ExpenseTag? ExpenseTag { get; set; }
-    public virtual BankAccount? BankAccount { get; set; }
-}
+    public BankoApi.Data.Dao.ExpenseTag? ExpenseTag { get; set; }
 
-public class CreditorAccount
-{
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public required string Iban { get; set; }
-    public required string Bban { get; set; }
-}
-
-public class Pending
-{
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public required DateTime BookingDate { get; set; }
-    public required string Amount { get; set; }
-    public required string Currency { get; set; }
-    public required string RemittanceInformationUnstructured { get; set; }
-    public required List<string> RemittanceInformationUnstructuredArray { get; set; }
+    // Bank info
+    public string? BankName { get; set; }
+    public string? BankLogoUrl { get; set; }
 }


### PR DESCRIPTION
## What

* Add Institution entity with FK from BankAuthorization and GET /Settings/institutions endpoint
* Add POST /Settings/institutions/sync-logos to backfill institution logos from GoCardless
* Add bankName/bankLogoUrl to transaction response via manual join on GoCardless account ID
* Fix Sequence contains no elements crash on empty Transactions table in GetTransactions
* Remove Transactions→BankAccounts FK constraint that blocked transaction inserts

## Why

* Bank logos and names should be surfaced in transaction details without storing redundant data
* A lazy fetch per transaction would waste GoCardless API quota; a one-shot sync endpoint is more efficient
* The FK constraint on Transaction.BankAccountId broke inserts because the column holds the GoCardless UUID, not the BankAccounts.Id PK; a manual join avoids this mismatch
* The .Min() call crashed when no transactions existed yet (e.g. after a failed sync that rolled back inserts)
* Frontend needs a proxied institutions list so GoCardless token management stays server-side