### PR TITLE
Feature/add bank gocardless

### DIFF
--- a/BankoApi.Tests/Controllers/SettingsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/SettingsControllerTests.cs
@@ -6,6 +6,7 @@ using BankoApi.Controllers.Settings.Responses;
 using BankoApi.Controllers.Settings;
 using BankoApi.Controllers.GoCardless.Requests;
 using BankoApi.Controllers.GoCardless.Responses;
+using BankoApi.Controllers.Shared;
 using BankoApi.Data;
 using BankoApi.Data.Dao;
 using BankoApi.Repository;
@@ -37,7 +38,7 @@ public class SettingsControllerTests
             var handlerMock = MockHelpers.CreateHandlerWithToken();
             goCardlessService = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         }
-        var controller = new SettingsController(goCardlessService, ctx, new BankAuthorizationRepository(), Mock.Of<ILogger<SettingsController>>());
+        var controller = new SettingsController(goCardlessService, ctx, new BankAuthorizationRepository(), new TransactionsRepository(), Mock.Of<ILogger<SettingsController>>());
         if (userId.HasValue)
         {
             var claims = new[] { new Claim(ClaimTypes.NameIdentifier, userId.Value.ToString()) };
@@ -526,7 +527,17 @@ public class SettingsControllerTests
             });
 
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
-        var controller = new SettingsController(service, ctx, new BankAuthorizationRepository(), Mock.Of<ILogger<SettingsController>>());
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+        var controller = CreateController(ctx, service, userId: userId);
         var request = new UpsertEndUserAgreementRequest
         {
             InstitutionId = "TEST_BANK",
@@ -631,7 +642,17 @@ public class SettingsControllerTests
             });
 
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
-        var controller = new SettingsController(service, ctx, new BankAuthorizationRepository(), Mock.Of<ILogger<SettingsController>>());
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+        var controller = CreateController(ctx, service, userId: userId);
         var request = new UpsertEndUserAgreementRequest();
 
         var result = await controller.UpsertEndUserAgreement(request);
@@ -639,5 +660,391 @@ public class SettingsControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsType<UpsertEndUserAgreementResponse>(okResult.Value);
         Assert.Equal("valid-eua", response.AgreementId);
+    }
+
+    [Fact]
+    public async Task UpsertEndUserAgreement_WithInstitutionId_SavesBankAuthorization()
+    {
+        using var ctx = CreateContext();
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("agreements/enduser/") && r.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new { count = 0, results = Array.Empty<object>() },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("agreements/enduser/") && r.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "eua-123",
+                        created = DateTime.UtcNow,
+                        institution_id = "TEST_BANK",
+                        max_historical_days = 30,
+                        access_valid_for_days = 30,
+                        access_scope = new[] { "balances", "transactions" },
+                        accepted = (DateTime?)null,
+                        reconfirmation = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("requisitions/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "req-abc",
+                        created = DateTime.UtcNow,
+                        redirect = "Banko://bank-auth-callback",
+                        status = "CR",
+                        institution_id = "TEST_BANK",
+                        agreement = "eua-123",
+                        reference = "ref-abc",
+                        accounts = Array.Empty<string>(),
+                        user_language = "EN",
+                        link = "https://bank.link/req",
+                        ssn = "",
+                        account_selection = false,
+                        redirect_immediate = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("institutions/TEST_BANK/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "TEST_BANK",
+                        name = "Test Bank",
+                        bic = "TESTBIC22",
+                        transaction_total_days = "180",
+                        countries = new[] { "GB" },
+                        logo = "https://example.com/logo.png",
+                        max_access_valid_for_days = "90"
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx, service, userId: userId);
+        var request = new UpsertEndUserAgreementRequest
+        {
+            InstitutionId = "TEST_BANK",
+            DaysOfAccess = 30
+        };
+
+        await controller.UpsertEndUserAgreement(request);
+
+        var savedAuth = ctx.BankAuthorizations.FirstOrDefault(ba => ba.RequisitionId == "req-abc");
+        Assert.NotNull(savedAuth);
+        Assert.Equal(BankAuthorizationStaus.Processing, savedAuth!.Status);
+        Assert.Equal(userId, savedAuth.UserId);
+        Assert.Equal("TEST_BANK", savedAuth.InstitutionId);
+    }
+
+    [Fact]
+    public async Task GetBankAuthorization_WithAccounts_ReturnsNestedAccounts()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var authId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = authId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            InstitutionId = "TEST_BANK",
+            InstitutionName = "Test Bank",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAccounts.Add(new BankAccount
+        {
+            Id = Guid.NewGuid(),
+            BankAuthorizationId = authId,
+            BankAccountId = "gc-acc-1",
+            Iban = "NO9386011117947",
+            Currency = "NOK",
+            OwnerName = "Test User",
+            AccountName = "Main Account",
+            Product = "Premium",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx, userId: userId);
+        var result = await controller.GetBankAuthorization();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<GetBankAuthorizationsResponse>(okResult.Value);
+        Assert.Single(response.BankAuthorizations);
+        Assert.Single(response.BankAuthorizations[0].Accounts);
+        Assert.Equal("gc-acc-1", response.BankAuthorizations[0].Accounts[0].BankAccountId);
+        Assert.Equal("NO9386011117947", response.BankAuthorizations[0].Accounts[0].Iban);
+        Assert.Equal("NOK", response.BankAuthorizations[0].Accounts[0].Currency);
+    }
+
+    [Fact]
+    public async Task GetBankAuthorization_NoAccounts_ReturnsEmptyList()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx, userId: userId);
+        var result = await controller.GetBankAuthorization();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<GetBankAuthorizationsResponse>(okResult.Value);
+        Assert.Single(response.BankAuthorizations);
+        Assert.Empty(response.BankAuthorizations[0].Accounts);
+    }
+
+    [Fact]
+    public async Task BankAuthCallback_NonLinkedStatus_ReturnsBadRequest()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        var authId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = authId,
+            UserId = userId,
+            RequisitionId = "req-pending",
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.Contains("requisitions/req-pending")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "req-pending",
+                        status = "CR",
+                        accounts = Array.Empty<string>()
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = CreateController(ctx, service, userId: userId);
+        var request = new BankAuthCallbackRequest { RequisitionId = "req-pending" };
+
+        var result = await controller.BankAuthCallback(request);
+
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        var errorResponse = Assert.IsType<ErrorResponse>(badRequestResult.Value);
+        Assert.Contains("CR", errorResponse.Message);
+
+        var updatedAuth = ctx.BankAuthorizations.Find(authId);
+        Assert.Equal(BankAuthorizationStaus.Error, updatedAuth!.Status);
+    }
+
+    [Fact]
+    public async Task BankAuthCallback_LinkedStatus_SavesAccountsAndTransactions()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        var authId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = authId,
+            UserId = userId,
+            RequisitionId = "req-success",
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        var accountId = Guid.NewGuid();
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.Contains("requisitions/req-success")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "req-success",
+                        status = "LN",
+                        accounts = new[] { accountId.ToString() }
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.Contains($"/accounts/{accountId}/details/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = accountId.ToString(),
+                        iban = "NO9386011117947",
+                        bban = "86011117947",
+                        currency = "NOK",
+                        owner_name = "Test User",
+                        display_name = "My Account",
+                        product = "Standard",
+                        status = "enabled"
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.Contains($"/accounts/{accountId}/transactions/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        transactions = new
+                        {
+                            booked = Array.Empty<object>(),
+                            pending = Array.Empty<object>()
+                        }
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = CreateController(ctx, service, userId: userId);
+        var request = new BankAuthCallbackRequest { RequisitionId = "req-success" };
+
+        var result = await controller.BankAuthCallback(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<BankAuthCallbackResponse>(okResult.Value);
+        Assert.Equal(BankAuthorizationStaus.Linked, response.Status);
+        Assert.Single(response.LinkedAccounts);
+        Assert.Equal("NO9386011117947", response.LinkedAccounts[0].Iban);
+        Assert.Equal("NOK", response.LinkedAccounts[0].Currency);
+
+        var savedAccount = ctx.BankAccounts.FirstOrDefault(ba => ba.BankAccountId == accountId.ToString());
+        Assert.NotNull(savedAccount);
+        Assert.Equal(authId, savedAccount!.BankAuthorizationId);
+
+        var updatedAuth = ctx.BankAuthorizations.Find(authId);
+        Assert.Equal(BankAuthorizationStaus.Linked, updatedAuth!.Status);
+    }
+
+    [Fact]
+    public async Task BankAuthCallback_NonExistingRequisition_ReturnsNotFound()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx, userId: userId);
+        var request = new BankAuthCallbackRequest { RequisitionId = "nonexistent" };
+
+        var result = await controller.BankAuthCallback(request);
+
+        Assert.IsType<NotFoundObjectResult>(result);
     }
 }

--- a/BankoApi/.envTemplate
+++ b/BankoApi/.envTemplate
@@ -2,4 +2,4 @@ DB_USER=<db username>
 DB_PASS=<db password>
 GOOGLE_CLOUD_IP=<0.0.0.0>
 GOCARDLESS_ID=<GoCardless secret ID for token>
-GOCARDLESS_ID_KEY=<GoCardless secret key for token>
+GOCARDLESS_KEY=<GoCardless secret key for token>

--- a/BankoApi/Controllers/GoCardless/Responses/UpsertEndUserAgreementResponse.cs
+++ b/BankoApi/Controllers/GoCardless/Responses/UpsertEndUserAgreementResponse.cs
@@ -7,5 +7,6 @@
         public String AgreementId { get; set; }
         public String ReferenceId { get; set; }
         public String InstitutionId { get; set; }
+        public Guid BankAuthorizationId { get; set; }
     }
 }

--- a/BankoApi/Controllers/Settings/BankAuthorizationController.cs
+++ b/BankoApi/Controllers/Settings/BankAuthorizationController.cs
@@ -20,7 +20,11 @@ namespace BankoApi.Controllers.Settings
             try
             {
                 var userId = User.GetUserId();
-                var result = _dbContext.BankAuthorizations.Where(ba => ba.UserId == userId).ToList();
+                var result = await _dbContext.BankAuthorizations
+                    .Where(ba => ba.UserId == userId)
+                    .Include(ba => ba.BankAccounts)
+                    .ToListAsync();
+
                 if (result.Count == 0) throw new NoBankAuthorizationFoundException($"The user {userId} doesn't have any bank authorization process started yet.");
                 return Ok(new GetBankAuthorizationsResponse
                 {
@@ -35,7 +39,16 @@ namespace BankoApi.Controllers.Settings
                         Status = it.Status,
                         InstitutionName = it.InstitutionName,
                         CreatedAt = it.CreatedAt,
-                        UpdatedAt = it.UpdatedAt
+                        UpdatedAt = it.UpdatedAt,
+                        Accounts = it.BankAccounts?.ToList().ConvertAll(acc => new BankAccountSummary()
+                        {
+                            BankAccountId = acc.BankAccountId,
+                            Iban = acc.Iban,
+                            Currency = acc.Currency,
+                            OwnerName = acc.OwnerName,
+                            AccountName = acc.AccountName,
+                            Product = acc.Product
+                        }) ?? new List<BankAccountSummary>()
                     })
                 });
             }
@@ -155,7 +168,20 @@ namespace BankoApi.Controllers.Settings
                 agreementId: validEua.Id
             );
 
-            // TODO: Salvare sul DB tutte le info necessarie
+            var userId = User.GetUserId();
+            var authorization = new BankAuthorization
+            {
+                UserId = userId,
+                RequisitionId = requisition.Id,
+                AgreementId = requisition.Agreement,
+                ReferenceId = requisition.Reference,
+                InstitutionId = requisition.InstitutionId,
+                InstitutionName = gcInstitution?.Name,
+                Status = BankAuthorizationStaus.Processing
+            };
+
+            _dbContext.BankAuthorizations.Add(authorization);
+            await _dbContext.SaveChangesAsync();
 
             return Ok(new UpsertEndUserAgreementResponse()
             {
@@ -163,7 +189,99 @@ namespace BankoApi.Controllers.Settings
                 Link = requisition.Link,
                 InstitutionId = requisition.InstitutionId,
                 RequisitionId = requisition.Id,
-                ReferenceId = requisition.Reference
+                ReferenceId = requisition.Reference,
+                BankAuthorizationId = authorization.Id
+            });
+        }
+
+        [HttpPost("bank-auth-callback")]
+        public async Task<IActionResult> BankAuthCallback([FromBody] BankAuthCallbackRequest request)
+        {
+            var userId = User.GetUserId();
+            var authorization = await _dbContext.BankAuthorizations
+                .FirstOrDefaultAsync(ba => ba.RequisitionId == request.RequisitionId && ba.UserId == userId);
+
+            if (authorization == null)
+            {
+                return NotFound(new ErrorResponse
+                {
+                    Message = BankAuthorizationErrorMessages.NoAuthorizationFound.ToString()
+                });
+            }
+
+            var requisition = await _goCardlessService.GetRequisitionAsync(request.RequisitionId);
+
+            if (requisition.Status != "LN")
+            {
+                authorization.Status = BankAuthorizationStaus.Error;
+                authorization.UpdatedAt = DateTime.UtcNow;
+                await _dbContext.SaveChangesAsync();
+
+                return BadRequest(new ErrorResponse
+                {
+                    Message = $"Authorization not completed. Status: {requisition.Status}"
+                });
+            }
+
+            var linkedAccounts = new List<LinkedBankAccount>();
+
+            foreach (var gcAccountId in requisition.Accounts)
+            {
+                Guid accountId = Guid.Parse(gcAccountId);
+
+                var details = await _goCardlessService.GetAccountDetailsAsync(accountId);
+
+                var bankAccount = new BankAccount
+                {
+                    BankAuthorizationId = authorization.Id,
+                    BankAccountId = gcAccountId,
+                    Iban = details?.Iban,
+                    Bban = details?.Bban,
+                    Currency = details?.Currency,
+                    OwnerName = details?.OwnerName,
+                    Product = details?.Product,
+                    AccountName = details?.DisplayName ?? details?.Name
+                };
+
+                _dbContext.BankAccounts.Add(bankAccount);
+
+                linkedAccounts.Add(new LinkedBankAccount
+                {
+                    BankAccountId = gcAccountId,
+                    Iban = details?.Iban,
+                    Currency = details?.Currency,
+                    OwnerName = details?.OwnerName,
+                    AccountName = details?.DisplayName ?? details?.Name,
+                    Product = details?.Product
+                });
+
+                try
+                {
+                    var transactions = await _goCardlessService.GetTransactionsAsync(accountId);
+                    if (transactions != null)
+                    {
+                        await _transactionsRepository.StoreTransactions(
+                            ctx: _dbContext,
+                            userId: userId,
+                            bankAccountId: accountId,
+                            transactions: transactions);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch initial transactions for account {AccountId}", gcAccountId);
+                }
+            }
+
+            authorization.Status = BankAuthorizationStaus.Linked;
+            authorization.UpdatedAt = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync();
+
+            return Ok(new BankAuthCallbackResponse
+            {
+                BankAuthorizationId = authorization.Id,
+                Status = authorization.Status,
+                LinkedAccounts = linkedAccounts
             });
         }
 

--- a/BankoApi/Controllers/Settings/Requests/BankAuthCallbackRequest.cs
+++ b/BankoApi/Controllers/Settings/Requests/BankAuthCallbackRequest.cs
@@ -1,0 +1,7 @@
+namespace BankoApi.Controllers.Settings.Requests
+{
+    public class BankAuthCallbackRequest
+    {
+        public String RequisitionId { get; set; } = string.Empty;
+    }
+}

--- a/BankoApi/Controllers/Settings/Responses/BankAuthCallbackResponse.cs
+++ b/BankoApi/Controllers/Settings/Responses/BankAuthCallbackResponse.cs
@@ -1,0 +1,21 @@
+using BankoApi.Data.Dao;
+
+namespace BankoApi.Controllers.Settings.Responses
+{
+    public class BankAuthCallbackResponse
+    {
+        public Guid BankAuthorizationId { get; set; }
+        public BankAuthorizationStaus Status { get; set; }
+        public List<LinkedBankAccount> LinkedAccounts { get; set; } = new();
+    }
+
+    public class LinkedBankAccount
+    {
+        public String BankAccountId { get; set; } = string.Empty;
+        public String? Iban { get; set; }
+        public String? Currency { get; set; }
+        public String? OwnerName { get; set; }
+        public String? AccountName { get; set; }
+        public String? Product { get; set; }
+    }
+}

--- a/BankoApi/Controllers/Settings/Responses/GetBankAuthorizationsResponse.cs
+++ b/BankoApi/Controllers/Settings/Responses/GetBankAuthorizationsResponse.cs
@@ -19,5 +19,16 @@ namespace BankoApi.Controllers.Settings.Responses
         public String? InstitutionName { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
+        public List<BankAccountSummary> Accounts { get; set; } = new();
+    }
+
+    public class BankAccountSummary
+    {
+        public String BankAccountId { get; set; } = string.Empty;
+        public String? Iban { get; set; }
+        public String? Currency { get; set; }
+        public String? OwnerName { get; set; }
+        public String? AccountName { get; set; }
+        public String? Product { get; set; }
     }
 }

--- a/BankoApi/Controllers/Settings/SettingsController.cs
+++ b/BankoApi/Controllers/Settings/SettingsController.cs
@@ -15,13 +15,15 @@ public partial class SettingsController : ControllerBase
     private readonly BankoDbContext _dbContext;
     private readonly GoCardlessService _goCardlessService;
     private readonly BankAuthorizationRepository _repository;
+    private readonly TransactionsRepository _transactionsRepository;
     private readonly ILogger<SettingsController> _logger;
 
-    public SettingsController(GoCardlessService goCardlessService, BankoDbContext dbContext, BankAuthorizationRepository repository, ILogger<SettingsController> logger)
+    public SettingsController(GoCardlessService goCardlessService, BankoDbContext dbContext, BankAuthorizationRepository repository, TransactionsRepository transactionsRepository, ILogger<SettingsController> logger)
     {
         _goCardlessService = goCardlessService;
         _dbContext = dbContext;
         _repository = repository;
+        _transactionsRepository = transactionsRepository;
         _logger = logger;
     }
 }

--- a/BankoApi/Services/GoCardlessService.cs
+++ b/BankoApi/Services/GoCardlessService.cs
@@ -125,4 +125,29 @@ public class GoCardlessService
 
         return response.Content.ReadFromJsonAsync<Model.Requisition>().Result;
     }
+
+    public async Task<Model.Requisition> GetRequisitionAsync(string requisitionId)
+    {
+        var token = await _tokenService.GetAccessTokenAsync();
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _httpClient.GetAsync($"requisitions/{requisitionId}/");
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<Model.Requisition>()
+            ?? throw new InvalidOperationException($"Failed to deserialize requisition {requisitionId}");
+    }
+
+    public async Task<GoCardlessAccountDetails?> GetAccountDetailsAsync(Guid accountId)
+    {
+        var token = await _tokenService.GetAccessTokenAsync();
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _httpClient.GetAsync($"accounts/{accountId}/details/");
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<GoCardlessAccountDetails>();
+    }
 }

--- a/BankoApi/Services/Model/GoCardlessAccountDetails.cs
+++ b/BankoApi/Services/Model/GoCardlessAccountDetails.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace BankoApi.Services.Model
+{
+    public class GoCardlessAccountDetails
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("iban")]
+        public string? Iban { get; set; }
+
+        [JsonPropertyName("bban")]
+        public string? Bban { get; set; }
+
+        [JsonPropertyName("bic")]
+        public string? Bic { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string? Currency { get; set; }
+
+        [JsonPropertyName("owner_name")]
+        public string? OwnerName { get; set; }
+
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("product")]
+        public string? Product { get; set; }
+
+        [JsonPropertyName("status")]
+        public string? Status { get; set; }
+
+        [JsonPropertyName("usage")]
+        public string? Usage { get; set; }
+    }
+}

--- a/BankoApi/Services/ScheduledTaskService.cs
+++ b/BankoApi/Services/ScheduledTaskService.cs
@@ -1,4 +1,5 @@
 using BankoApi.Data;
+using BankoApi.Exceptions.GoCardless.Transactions;
 using BankoApi.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -57,9 +58,9 @@ public class ScheduledTaskService : BackgroundService
                 .Select(y => y.BankAccountId)
                 .ToListAsync();
 
-            if (bankAccountIds.Count != 0)
+            foreach (var gcAccountId in bankAccountIds)
             {
-                foreach (var gcAccountId in bankAccountIds)
+                try
                 {
                     Guid bankAccountId = Guid.Parse(gcAccountId);
                     var transactions = await goCardlessService.GetTransactionsAsync(bankAccountId);
@@ -68,6 +69,15 @@ public class ScheduledTaskService : BackgroundService
                         await repository.StoreTransactions(ctx: dbContext, userId: userId, transactions: transactions, bankAccountId: bankAccountId);
                         await dbContext.SaveChangesAsync();
                     }
+                }
+                catch (EndUserAgreementException ex)
+                {
+                    _logger.LogError(ex, "EUA expired for user {UserId}, account {AccountId}", userId, gcAccountId);
+                    repository.SetEuaExpirationStatus(dbContext, ex.Message);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch transactions for user {UserId}, account {AccountId}", userId, gcAccountId);
                 }
             }
         }


### PR DESCRIPTION
## What
- Add GetRequisitionAsync and GetAccountDetailsAsync to GoCardlessService
- Add GoCardlessAccountDetails model for account details API response
- Add POST /Settings/bank-auth-callback endpoint for post-authorization flow
- Modify UpsertEndUserAgreement to save BankAuthorization as Processing after creating requisition
- Enrich GET /Settings/BankAuthorization with nested BankAccountSummary list
- Add BankAuthorizationId to UpsertEndUserAgreementResponse
- Add TransactionsRepository dependency to SettingsController
- Improve ScheduledTaskService with per-account error handling and EUA expiration detection
- Add 6 new unit tests covering callback success/failure, nested accounts, and EUA persistence

## Why
-Users can now link multiple bank accounts through GoCardless, not just one
- Bank authorization state is tracked end-to-end: Processing → Linked / Error / Expired
- Bank account details (IBAN, currency, owner name) are stored only after the user completes bank authorization in the WebView
- Initial transactions are fetched immediately after authorization, reducing wait time for the user
- Per-account error handling in ScheduledTaskService prevents one failed bank from blocking all others
- Settings API now returns linked accounts nested inside each authorization, reducing the number of API calls the frontend needs