### PR TITLE
fix: redirect stuck in Chrome and stale processing cleanup

### DIFF
--- a/BankoApi.Tests/Services/ScheduledTaskServiceTests.cs
+++ b/BankoApi.Tests/Services/ScheduledTaskServiceTests.cs
@@ -178,4 +178,62 @@ public class ScheduledTaskServiceTests
         await Task.Delay(200);
         await scheduledService.StopAsync(cts.Token);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_StaleProcessingAuthorizations_AreDeleted()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        var staleAuthId = Guid.NewGuid();
+        var recentAuthId = Guid.NewGuid();
+        var linkedAuthId = Guid.NewGuid();
+
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = staleAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow.AddHours(-25),
+            UpdatedAt = DateTime.UtcNow.AddHours(-25)
+        });
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = recentAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = linkedAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow.AddHours(-25),
+            UpdatedAt = DateTime.UtcNow.AddHours(-25)
+        });
+        ctx.SaveChanges();
+
+        var threshold = DateTime.UtcNow.AddHours(-24);
+        var staleAuthorizations = await ctx.BankAuthorizations
+            .Where(ba => ba.Status == BankAuthorizationStaus.Processing && ba.CreatedAt < threshold)
+            .ToListAsync();
+
+        ctx.BankAuthorizations.RemoveRange(staleAuthorizations);
+        await ctx.SaveChangesAsync();
+
+        var remaining = ctx.BankAuthorizations.ToList();
+        Assert.Single(remaining, ba => ba.Id == recentAuthId);
+        Assert.Single(remaining, ba => ba.Id == linkedAuthId);
+        Assert.DoesNotContain(remaining, ba => ba.Id == staleAuthId);
+    }
 }

--- a/BankoApi/Services/GoCardlessService.cs
+++ b/BankoApi/Services/GoCardlessService.cs
@@ -114,6 +114,7 @@ public class GoCardlessService
         var formData = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             { "redirect", "Banko://bank-auth-callback" },
+            { "redirect_immediate", "true" },
             { "institution_id", institutionId },
             { "agreement", agreementId },
             { "reference", Guid.NewGuid().ToString() },

--- a/BankoApi/Services/ScheduledTaskService.cs
+++ b/BankoApi/Services/ScheduledTaskService.cs
@@ -1,4 +1,5 @@
 using BankoApi.Data;
+using BankoApi.Data.Dao;
 using BankoApi.Exceptions.GoCardless.Transactions;
 using BankoApi.Repository;
 using Microsoft.EntityFrameworkCore;
@@ -40,6 +41,15 @@ public class ScheduledTaskService : BackgroundService
             {
                 _logger.LogError(ex, "Error occurred while fetching and storing transactions");
             }
+
+            try
+            {
+                await CleanupStaleProcessingAuthorizations();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while cleaning up stale processing authorizations");
+            }
         }
     }
 
@@ -80,6 +90,24 @@ public class ScheduledTaskService : BackgroundService
                     _logger.LogError(ex, "Failed to fetch transactions for user {UserId}, account {AccountId}", userId, gcAccountId);
                 }
             }
+        }
+    }
+
+    private async Task CleanupStaleProcessingAuthorizations()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<BankoDbContext>();
+
+        var threshold = DateTime.UtcNow.AddHours(-24);
+        var staleAuthorizations = await dbContext.BankAuthorizations
+            .Where(ba => ba.Status == BankAuthorizationStaus.Processing && ba.CreatedAt < threshold)
+            .ToListAsync();
+
+        if (staleAuthorizations.Count > 0)
+        {
+            dbContext.BankAuthorizations.RemoveRange(staleAuthorizations);
+            await dbContext.SaveChangesAsync();
+            _logger.LogInformation("Cleaned up {Count} stale processing authorizations", staleAuthorizations.Count);
         }
     }
 }


### PR DESCRIPTION
## What

* Added `redirect_immediate: true` to GoCardless requisition creation
* Added `CleanupStaleProcessingAuthorizations()` to the daily scheduled task that deletes `BankAuthorization` records stuck in `Processing` for more than 24 hours
* Added test for the stale Processing cleanup logic

## Why

* Without `redirect_immediate`, GoCardless shows an intermediate success page that redirects to `Banko://bank-auth-callback` via JavaScript. Browsers block JS redirects to custom URI schemes, so the auth flow gets stuck in a Chrome tab and never deep-links back to the app. With `redirect_immediate`, GoCardless does an HTTP 302 redirect directly, which browsers do follow for custom schemes.
* When a user cancels the bank authorization webview and the mobile app never calls the callback endpoint, the `BankAuthorization` record stays in `Processing` forever. The cleanup job removes these stale records as a safety net.
* The cleanup query logic needed verification to ensure it only deletes stale Processing records while preserving recent Processing and Linked records.