### PR TITLE
Fix/bank auth redirect and stale cleanup

### DIFF
--- a/BankoApi.Tests/Services/ScheduledTaskServiceTests.cs
+++ b/BankoApi.Tests/Services/ScheduledTaskServiceTests.cs
@@ -178,4 +178,62 @@ public class ScheduledTaskServiceTests
         await Task.Delay(200);
         await scheduledService.StopAsync(cts.Token);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_StaleProcessingAuthorizations_AreDeleted()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        var staleAuthId = Guid.NewGuid();
+        var recentAuthId = Guid.NewGuid();
+        var linkedAuthId = Guid.NewGuid();
+
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = staleAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow.AddHours(-25),
+            UpdatedAt = DateTime.UtcNow.AddHours(-25)
+        });
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = recentAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Processing,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = linkedAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow.AddHours(-25),
+            UpdatedAt = DateTime.UtcNow.AddHours(-25)
+        });
+        ctx.SaveChanges();
+
+        var threshold = DateTime.UtcNow.AddHours(-24);
+        var staleAuthorizations = await ctx.BankAuthorizations
+            .Where(ba => ba.Status == BankAuthorizationStaus.Processing && ba.CreatedAt < threshold)
+            .ToListAsync();
+
+        ctx.BankAuthorizations.RemoveRange(staleAuthorizations);
+        await ctx.SaveChangesAsync();
+
+        var remaining = ctx.BankAuthorizations.ToList();
+        Assert.Single(remaining, ba => ba.Id == recentAuthId);
+        Assert.Single(remaining, ba => ba.Id == linkedAuthId);
+        Assert.DoesNotContain(remaining, ba => ba.Id == staleAuthId);
+    }
 }

--- a/BankoApi/Controllers/Settings/BankAuthorizationController.cs
+++ b/BankoApi/Controllers/Settings/BankAuthorizationController.cs
@@ -23,9 +23,37 @@ namespace BankoApi.Controllers.Settings
                 var result = await _dbContext.BankAuthorizations
                     .Where(ba => ba.UserId == userId)
                     .Include(ba => ba.BankAccounts)
+                    .Include(ba => ba.Institution)
                     .ToListAsync();
 
                 if (result.Count == 0) throw new NoBankAuthorizationFoundException($"The user {userId} doesn't have any bank authorization process started yet.");
+
+                var missingLogos = result
+                    .Where(ba => ba.Institution != null && string.IsNullOrEmpty(ba.Institution.LogoUrl) && ba.InstitutionId != null)
+                    .Select(ba => ba.Institution!)
+                    .Distinct()
+                    .ToList();
+
+                foreach (var institution in missingLogos)
+                {
+                    try
+                    {
+                        var gcInstitution = await _goCardlessService.GetInstitutionAsync(institution.Id);
+                        if (gcInstitution?.Logo != null)
+                        {
+                            institution.LogoUrl = gcInstitution.Logo;
+                            institution.UpdatedAt = DateTime.UtcNow;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to fetch logo for institution {InstitutionId}", institution.Id);
+                    }
+                }
+
+                if (missingLogos.Count > 0)
+                    await _dbContext.SaveChangesAsync();
+
                 return Ok(new GetBankAuthorizationsResponse
                 {
                     BankAuthorizations = result.ConvertAll(it => new BankAuth()
@@ -38,6 +66,7 @@ namespace BankoApi.Controllers.Settings
                         AgreementId = it.AgreementId,
                         Status = it.Status,
                         InstitutionName = it.InstitutionName,
+                        InstitutionLogoUrl = it.Institution?.LogoUrl,
                         CreatedAt = it.CreatedAt,
                         UpdatedAt = it.UpdatedAt,
                         Accounts = it.BankAccounts?.ToList().ConvertAll(acc => new BankAccountSummary()

--- a/BankoApi/Controllers/Settings/Responses/GetBankAuthorizationsResponse.cs
+++ b/BankoApi/Controllers/Settings/Responses/GetBankAuthorizationsResponse.cs
@@ -17,6 +17,7 @@ namespace BankoApi.Controllers.Settings.Responses
         public String? AgreementId { get; set; }
         public BankAuthorizationStaus Status { get; set; }
         public String? InstitutionName { get; set; }
+        public String? InstitutionLogoUrl { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public List<BankAccountSummary> Accounts { get; set; } = new();

--- a/BankoApi/Services/GoCardlessService.cs
+++ b/BankoApi/Services/GoCardlessService.cs
@@ -114,6 +114,7 @@ public class GoCardlessService
         var formData = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             { "redirect", "Banko://bank-auth-callback" },
+            { "redirect_immediate", "true" },
             { "institution_id", institutionId },
             { "agreement", agreementId },
             { "reference", Guid.NewGuid().ToString() },

--- a/BankoApi/Services/ScheduledTaskService.cs
+++ b/BankoApi/Services/ScheduledTaskService.cs
@@ -1,4 +1,5 @@
 using BankoApi.Data;
+using BankoApi.Data.Dao;
 using BankoApi.Exceptions.GoCardless.Transactions;
 using BankoApi.Repository;
 using Microsoft.EntityFrameworkCore;
@@ -40,6 +41,15 @@ public class ScheduledTaskService : BackgroundService
             {
                 _logger.LogError(ex, "Error occurred while fetching and storing transactions");
             }
+
+            try
+            {
+                await CleanupStaleProcessingAuthorizations();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while cleaning up stale processing authorizations");
+            }
         }
     }
 
@@ -80,6 +90,24 @@ public class ScheduledTaskService : BackgroundService
                     _logger.LogError(ex, "Failed to fetch transactions for user {UserId}, account {AccountId}", userId, gcAccountId);
                 }
             }
+        }
+    }
+
+    private async Task CleanupStaleProcessingAuthorizations()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<BankoDbContext>();
+
+        var threshold = DateTime.UtcNow.AddHours(-24);
+        var staleAuthorizations = await dbContext.BankAuthorizations
+            .Where(ba => ba.Status == BankAuthorizationStaus.Processing && ba.CreatedAt < threshold)
+            .ToListAsync();
+
+        if (staleAuthorizations.Count > 0)
+        {
+            dbContext.BankAuthorizations.RemoveRange(staleAuthorizations);
+            await dbContext.SaveChangesAsync();
+            _logger.LogInformation("Cleaned up {Count} stale processing authorizations", staleAuthorizations.Count);
         }
     }
 }


### PR DESCRIPTION
### What
- Add `InstitutionLogoUrl` to `BankAuth` response DTO
- Include `Institution` navigation property in bank authorizations query
- Auto-populate missing institution logos from GoCardless on first access
- Fix redirect URL stuck in Chrome and clean up stale processing states

### Why
- The linked banks screen needs institution logos but the `Institution` table was seeded without them during migration
- Auto-populating on first access ensures logos appear without requiring manual data fixes or re-linking
- Stale processing states could leave bank connections stuck in limbo