### PR TITLE
fix: scope all endpoints by JWT UserId to prevent cross-user data leakage

### DIFF
--- a/BankoApi.Tests/Controllers/BankoApiTransactionsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/BankoApiTransactionsControllerTests.cs
@@ -1,8 +1,10 @@
+using System.Security.Claims;
 using BankoApi.Controllers.Settings.Requests;
 using BankoApi.Controllers.Transactions;
 using BankoApi.Controllers.Transactions.Requests;
 using BankoApi.Data;
 using BankoApi.Data.Dao;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,6 +12,8 @@ namespace BankoApi.Tests.Controllers;
 
 public class BankoApiTransactionsControllerTests
 {
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
     private BankoDbContext CreateContext()
     {
         var options = new DbContextOptionsBuilder<BankoDbContext>()
@@ -18,12 +22,30 @@ public class BankoApiTransactionsControllerTests
         return new BankoDbContext(options);
     }
 
+    private static TransactionsController CreateControllerWithUser(BankoDbContext ctx)
+    {
+        var controller = new TransactionsController(ctx)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.NameIdentifier, TestUserId.ToString())
+                    }))
+                }
+            }
+        };
+        return controller;
+    }
+
     [Fact]
     public async Task GetTransactions_NoFilters_ReturnsOk()
     {
         using var ctx = CreateContext();
         SeedTransaction(ctx);
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
 
         var result = await controller.GetTransactions();
 
@@ -36,7 +58,7 @@ public class BankoApiTransactionsControllerTests
     {
         using var ctx = CreateContext();
         SeedTransaction(ctx);
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
 
         var fromDate = new DateTime(2024, 1, 1);
         var toDate = new DateTime(2024, 12, 31);
@@ -51,7 +73,7 @@ public class BankoApiTransactionsControllerTests
     public async Task GetTransactions_InvalidPageNumber_ReturnsBadRequest()
     {
         using var ctx = CreateContext();
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
 
         var result = await controller.GetTransactions(pageNumber: 0);
 
@@ -62,7 +84,7 @@ public class BankoApiTransactionsControllerTests
     public async Task GetTransactions_InvalidPageSize_ReturnsBadRequest()
     {
         using var ctx = CreateContext();
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
 
         var result = await controller.GetTransactions(pageSize: 0);
 
@@ -73,7 +95,7 @@ public class BankoApiTransactionsControllerTests
     public async Task GetTransactions_FromDateAfterToDate_ReturnsBadRequest()
     {
         using var ctx = CreateContext();
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
 
         var result = await controller.GetTransactions(
             fromDate: new DateTime(2024, 12, 31),
@@ -89,7 +111,7 @@ public class BankoApiTransactionsControllerTests
         var tx = new Transaction
         {
             Id = "tx-to-delete",
-            UserId = Guid.NewGuid(),
+            UserId = TestUserId,
             BankAccountId = Guid.NewGuid(),
             BookingDate = DateTime.UtcNow,
             ValueDate = DateTime.UtcNow,
@@ -102,7 +124,7 @@ public class BankoApiTransactionsControllerTests
         ctx.Transactions.Add(tx);
         ctx.SaveChanges();
 
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
         var result = await controller.DeleteTransaction("tx-to-delete");
 
         Assert.IsType<OkObjectResult>(result);
@@ -113,7 +135,7 @@ public class BankoApiTransactionsControllerTests
     public async Task DeleteTransaction_NonExistingTransaction_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
 
         var result = await controller.DeleteTransaction("non-existent");
 
@@ -135,7 +157,7 @@ public class BankoApiTransactionsControllerTests
         var tx = new Transaction
         {
             Id = "tx-tag-update",
-            UserId = Guid.NewGuid(),
+            UserId = TestUserId,
             BankAccountId = Guid.NewGuid(),
             BookingDate = DateTime.UtcNow,
             ValueDate = DateTime.UtcNow,
@@ -148,7 +170,7 @@ public class BankoApiTransactionsControllerTests
         ctx.Transactions.Add(tx);
         ctx.SaveChanges();
 
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
         var request = new UpdateExpenseTagRequest
         {
             TransactionId = "tx-tag-update",
@@ -169,7 +191,7 @@ public class BankoApiTransactionsControllerTests
         var tx = new Transaction
         {
             Id = "tx-clear-tag",
-            UserId = Guid.NewGuid(),
+            UserId = TestUserId,
             BankAccountId = Guid.NewGuid(),
             BookingDate = DateTime.UtcNow,
             ValueDate = DateTime.UtcNow,
@@ -183,7 +205,7 @@ public class BankoApiTransactionsControllerTests
         ctx.Transactions.Add(tx);
         ctx.SaveChanges();
 
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
         var request = new UpdateExpenseTagRequest
         {
             TransactionId = "tx-clear-tag",
@@ -201,7 +223,7 @@ public class BankoApiTransactionsControllerTests
     public async Task UpdateExpenseTags_NonExistingTransaction_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
         var request = new UpdateExpenseTagRequest
         {
             TransactionId = "non-existent",
@@ -220,7 +242,7 @@ public class BankoApiTransactionsControllerTests
         var tx = new Transaction
         {
             Id = "tx-note",
-            UserId = Guid.NewGuid(),
+            UserId = TestUserId,
             BankAccountId = Guid.NewGuid(),
             BookingDate = DateTime.UtcNow,
             ValueDate = DateTime.UtcNow,
@@ -233,7 +255,7 @@ public class BankoApiTransactionsControllerTests
         ctx.Transactions.Add(tx);
         ctx.SaveChanges();
 
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
         var request = new UpdateNoteRequest { Note = "Updated note" };
 
         var result = await controller.UpdateNote("tx-note", request);
@@ -247,7 +269,7 @@ public class BankoApiTransactionsControllerTests
     public async Task UpdateNote_NonExistingTransaction_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        var controller = new TransactionsController(ctx);
+        var controller = CreateControllerWithUser(ctx);
         var request = new UpdateNoteRequest { Note = "Note" };
 
         var result = await controller.UpdateNote("non-existent", request);
@@ -260,7 +282,7 @@ public class BankoApiTransactionsControllerTests
         ctx.Transactions.Add(new Transaction
         {
             Id = "tx-1",
-            UserId = Guid.NewGuid(),
+            UserId = TestUserId,
             BankAccountId = Guid.NewGuid(),
             BookingDate = new DateTime(2024, 6, 15),
             ValueDate = new DateTime(2024, 6, 15),

--- a/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/GoCardlessTransactionsControllerTests.cs
@@ -43,6 +43,27 @@ public class GoCardlessTransactionsControllerTests
     {
         using var ctx = CreateContext();
         var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+
+        var bankAuthId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAccounts.Add(new BankAccount
+        {
+            Id = Guid.NewGuid(),
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = bankAccountId.ToString(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
         var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
             new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -50,7 +71,6 @@ public class GoCardlessTransactionsControllerTests
             });
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         var controller = CreateController(ctx, service, userId);
-        var bankAccountId = Guid.NewGuid();
 
         var result = await controller.FetchAndStoreTransactions(bankAccountId);
 
@@ -62,6 +82,9 @@ public class GoCardlessTransactionsControllerTests
     {
         using var ctx = CreateContext();
         var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var agreementId = Guid.NewGuid().ToString();
+
         ctx.Users.Add(new User
         {
             UserId = userId,
@@ -70,13 +93,21 @@ public class GoCardlessTransactionsControllerTests
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         });
-        var agreementId = Guid.NewGuid().ToString();
+        var bankAuthId = Guid.NewGuid();
         ctx.BankAuthorizations.Add(new BankAuthorization
         {
-            Id = Guid.NewGuid(),
+            Id = bankAuthId,
             UserId = userId,
             AgreementId = agreementId,
             Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAccounts.Add(new BankAccount
+        {
+            Id = Guid.NewGuid(),
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = bankAccountId.ToString(),
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         });
@@ -90,7 +121,6 @@ public class GoCardlessTransactionsControllerTests
             });
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         var controller = CreateController(ctx, service, userId);
-        var bankAccountId = Guid.NewGuid();
 
         var result = await controller.FetchAndStoreTransactions(bankAccountId);
 
@@ -102,13 +132,31 @@ public class GoCardlessTransactionsControllerTests
     {
         using var ctx = CreateContext();
         var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
 
-        // Return 500 to cause HttpRequestException
+        var bankAuthId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAccounts.Add(new BankAccount
+        {
+            Id = Guid.NewGuid(),
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = bankAccountId.ToString(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
         var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
             new HttpResponseMessage(HttpStatusCode.InternalServerError));
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         var controller = CreateController(ctx, service, userId);
-        var bankAccountId = Guid.NewGuid();
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
             controller.FetchAndStoreTransactions(bankAccountId));
@@ -119,6 +167,26 @@ public class GoCardlessTransactionsControllerTests
     {
         using var ctx = CreateContext();
         var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+
+        var bankAuthId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.BankAccounts.Add(new BankAccount
+        {
+            Id = Guid.NewGuid(),
+            BankAuthorizationId = bankAuthId,
+            BankAccountId = bankAccountId.ToString(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
 
         var transactionsResponse = new
         {
@@ -137,7 +205,6 @@ public class GoCardlessTransactionsControllerTests
             });
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
         var controller = CreateController(ctx, service, userId);
-        var bankAccountId = Guid.NewGuid();
 
         var result = await controller.FetchAndStoreTransactions(bankAccountId);
 

--- a/BankoApi.Tests/Controllers/SettingsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/SettingsControllerTests.cs
@@ -23,6 +23,8 @@ namespace BankoApi.Tests.Controllers;
 
 public class SettingsControllerTests
 {
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
     private BankoDbContext CreateContext()
     {
         var options = new DbContextOptionsBuilder<BankoDbContext>()
@@ -59,13 +61,14 @@ public class SettingsControllerTests
         ctx.ExpenseTag.Add(new ExpenseTag
         {
             Id = "tag-1",
+            UserId = TestUserId,
             Name = "Groceries",
             Color = 0xFF0000,
             isEarning = false
         });
         ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: TestUserId);
         var result = await controller.GetAllTagsAsync();
 
         var okResult = Assert.IsType<OkObjectResult>(result);
@@ -77,7 +80,7 @@ public class SettingsControllerTests
     public async Task GetAllTagsAsync_NoTags_ReturnsEmptyList()
     {
         using var ctx = CreateContext();
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: TestUserId);
 
         var result = await controller.GetAllTagsAsync();
 
@@ -90,7 +93,7 @@ public class SettingsControllerTests
     public async Task AddExpenseTagAsync_ValidTag_ReturnsOk()
     {
         using var ctx = CreateContext();
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: TestUserId);
         var tag = new ExpenseTag
         {
             Id = "new-tag",
@@ -103,6 +106,7 @@ public class SettingsControllerTests
 
         Assert.IsType<OkObjectResult>(result);
         Assert.Single(ctx.ExpenseTag);
+        Assert.Equal(TestUserId, ctx.ExpenseTag.First().UserId);
     }
 
     [Fact]
@@ -112,13 +116,14 @@ public class SettingsControllerTests
         ctx.ExpenseTag.Add(new ExpenseTag
         {
             Id = "tag-update",
+            UserId = TestUserId,
             Name = "Old Name",
             Color = 0x000000,
             isEarning = false
         });
         ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: TestUserId);
         var updatedTag = new ExpenseTag
         {
             Id = "tag-update",
@@ -140,7 +145,7 @@ public class SettingsControllerTests
     public async Task UpdateExpenseTagAsync_NonExistingTag_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: TestUserId);
         var updatedTag = new ExpenseTag
         {
             Id = "nonexistent",
@@ -161,13 +166,14 @@ public class SettingsControllerTests
         ctx.ExpenseTag.Add(new ExpenseTag
         {
             Id = "tag-delete",
+            UserId = TestUserId,
             Name = "Delete Me",
             Color = 0,
             isEarning = false
         });
         ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: TestUserId);
         var result = await controller.DeleteExpenseTagAsync("tag-delete");
 
         Assert.IsType<OkObjectResult>(result);
@@ -178,7 +184,7 @@ public class SettingsControllerTests
     public async Task DeleteExpenseTagAsync_NonExistingTag_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: TestUserId);
 
         var result = await controller.DeleteExpenseTagAsync("nonexistent");
 
@@ -220,41 +226,14 @@ public class SettingsControllerTests
     }
 
     [Fact]
-    public async Task UpsertBankAuthorization_InvalidUser_ReturnsUnauthorized()
-    {
-        using var ctx = CreateContext();
-        var controller = CreateController(ctx);
-        var request = new UpsertBankAuthorizationRequest
-        {
-            UserId = Guid.NewGuid(),
-            Status = BankAuthorizationStaus.Processing,
-            AgreementId = "agreement-1"
-        };
-
-        var result = await controller.UpsertBankAuthorization(request);
-
-        Assert.IsType<UnauthorizedResult>(result);
-    }
-
-    [Fact]
     public async Task UpsertBankAuthorization_NewAuthorization_CreatesIt()
     {
         using var ctx = CreateContext();
         var userId = Guid.NewGuid();
-        ctx.Users.Add(new User
-        {
-            UserId = userId,
-            Email = "test@example.com",
-            IsActive = true,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        });
-        ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: userId);
         var request = new UpsertBankAuthorizationRequest
         {
-            UserId = userId,
             Status = BankAuthorizationStaus.Processing,
             AgreementId = "agreement-new",
             InstitutionId = "TEST_BANK",
@@ -267,6 +246,7 @@ public class SettingsControllerTests
         var response = Assert.IsType<UpsertBankAuthorizationResponse>(okResult.Value);
         Assert.Equal("agreement-new", response.AgreementId);
         Assert.Equal("TEST_BANK", response.InstitutionId);
+        Assert.Equal(userId, response.UserId);
     }
 
     [Fact]
@@ -274,14 +254,6 @@ public class SettingsControllerTests
     {
         using var ctx = CreateContext();
         var userId = Guid.NewGuid();
-        ctx.Users.Add(new User
-        {
-            UserId = userId,
-            Email = "test@example.com",
-            IsActive = true,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        });
         var authId = Guid.NewGuid();
         ctx.BankAuthorizations.Add(new BankAuthorization
         {
@@ -294,10 +266,9 @@ public class SettingsControllerTests
         });
         ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: userId);
         var request = new UpsertBankAuthorizationRequest
         {
-            UserId = userId,
             Status = BankAuthorizationStaus.Linked,
             AgreementId = "agreement-existing",
             RequisitionId = "req-1"
@@ -315,7 +286,16 @@ public class SettingsControllerTests
     public async Task GetBankAccount_ValidIds_ReturnsAccounts()
     {
         using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
         var bankAuthId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
         ctx.BankAccounts.Add(new BankAccount
         {
             Id = Guid.NewGuid(),
@@ -328,7 +308,7 @@ public class SettingsControllerTests
         });
         ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: userId);
         var result = await controller.GetBankAccount(new List<string> { "acc-1" });
 
         var okResult = Assert.IsType<OkObjectResult>(result);
@@ -351,7 +331,7 @@ public class SettingsControllerTests
     public async Task GetBankAccount_NonExistingId_ReturnsNotFound()
     {
         using var ctx = CreateContext();
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: Guid.NewGuid());
 
         var result = await controller.GetBankAccount(new List<string> { "nonexistent" });
 
@@ -362,8 +342,19 @@ public class SettingsControllerTests
     public async Task UpsertBankAccount_NewAccount_CreatesIt()
     {
         using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
         var bankAuthId = Guid.NewGuid();
-        var controller = CreateController(ctx);
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx, userId: userId);
         var request = new UpsertBankAccountRequest
         {
             BankAuthorizationId = bankAuthId,
@@ -385,7 +376,16 @@ public class SettingsControllerTests
     public async Task UpsertBankAccount_ExistingAccount_UpdatesIt()
     {
         using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
         var bankAuthId = Guid.NewGuid();
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = bankAuthId,
+            UserId = userId,
+            Status = BankAuthorizationStaus.Linked,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
         ctx.BankAccounts.Add(new BankAccount
         {
             Id = Guid.NewGuid(),
@@ -397,7 +397,7 @@ public class SettingsControllerTests
         });
         ctx.SaveChanges();
 
-        var controller = CreateController(ctx);
+        var controller = CreateController(ctx, userId: userId);
         var request = new UpsertBankAccountRequest
         {
             BankAuthorizationId = bankAuthId,

--- a/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
@@ -3,7 +3,6 @@ using BankoApi.Data.Dao;
 using BankoApi.Repository;
 using BankoApi.Services.Model;
 using Microsoft.EntityFrameworkCore;
-using PendingDto = BankoApi.Services.Model.Pending;
 
 namespace BankoApi.Tests.Repository;
 
@@ -57,20 +56,6 @@ public class TransactionsRepositoryTests
                         InternalTransactionId = "internal-2",
                         BankTransactionCode = "PMNT"
                     }
-                },
-                Pending = new List<PendingDto>
-                {
-                    new()
-                    {
-                        BookingDate = "2024-01-17",
-                        TransactionAmount = new TransactionAmount
-                        {
-                            Amount = "50.00",
-                            Currency = "EUR"
-                        },
-                        RemittanceInformationUnstructured = "Pending payment",
-                        RemittanceInformationUnstructuredArray = new List<string> { "Pending payment" }
-                    }
                 }
             }
         };
@@ -89,7 +74,6 @@ public class TransactionsRepositoryTests
         await ctx.SaveChangesAsync();
 
         Assert.Equal(2, ctx.Transactions.Count());
-        Assert.Equal(1, ctx.Pendings.Count());
     }
 
     [Fact]
@@ -150,8 +134,7 @@ public class TransactionsRepositoryTests
                         RemittanceInformationUnstructuredArray = new List<string> { "No ID" },
                         InternalTransactionId = "internal-new"
                     }
-                },
-                Pending = new List<PendingDto>()
+                }
             }
         };
 

--- a/BankoApi.Tests/Utilities/TransactionExtensionsTests.cs
+++ b/BankoApi.Tests/Utilities/TransactionExtensionsTests.cs
@@ -2,7 +2,6 @@ using BankoApi.Data;
 using BankoApi.Data.Dao;
 using BankoApi.Services.Model;
 using Microsoft.EntityFrameworkCore;
-using PendingDto = BankoApi.Services.Model.Pending;
 using ServiceCreditorAccount = BankoApi.Services.Model.CreditorAccount;
 using ServiceDebtorAccount = BankoApi.Services.Model.DebtorAccount;
 
@@ -52,8 +51,7 @@ public class TransactionExtensionsTests
                             Bban = "00000000000"
                         }
                     }
-                },
-                Pending = new List<PendingDto>()
+                }
             }
         };
 
@@ -80,8 +78,7 @@ public class TransactionExtensionsTests
         {
             BankTransactions = new BankTransactions
             {
-                Booked = new List<Booked>(),
-                Pending = new List<PendingDto>()
+                Booked = new List<Booked>()
             }
         };
 
@@ -128,8 +125,7 @@ public class TransactionExtensionsTests
                             Bban = "existing-bban"
                         }
                     }
-                },
-                Pending = new List<PendingDto>()
+                }
             }
         };
 
@@ -138,65 +134,5 @@ public class TransactionExtensionsTests
         Assert.Single(result);
         Assert.NotNull(result[0].DebtorAccount);
         Assert.Equal(existingIban, result[0].DebtorAccount.Iban);
-    }
-
-    [Fact]
-    public void ToPendingDao_PendingTransactions_ReturnsDaoList()
-    {
-        var pendings = new List<PendingDto>
-        {
-            new()
-            {
-                BookingDate = "2024-06-20",
-                TransactionAmount = new TransactionAmount
-                {
-                    Amount = "75.00",
-                    Currency = "EUR"
-                },
-                RemittanceInformationUnstructured = "Pending tx",
-                RemittanceInformationUnstructuredArray = new List<string> { "Pending tx" }
-            }
-        };
-
-        var result = pendings.ToPendingDao();
-
-        Assert.Single(result);
-        Assert.Equal("75.00", result[0].Amount);
-        Assert.Equal("EUR", result[0].Currency);
-    }
-
-    [Fact]
-    public void ToPendingDao_EmptyList_ReturnsEmptyList()
-    {
-        var pendings = new List<PendingDto>();
-
-        var result = pendings.ToPendingDao();
-
-        Assert.Empty(result);
-    }
-
-    [Fact]
-    public void ToPendingDao_NullableFields_NullCoalescingApplied()
-    {
-        var pendings = new List<PendingDto>
-        {
-            new()
-            {
-                BookingDate = "2024-06-20",
-                TransactionAmount = new TransactionAmount
-                {
-                    Amount = "50.00",
-                    Currency = "USD"
-                },
-                RemittanceInformationUnstructured = null,
-                RemittanceInformationUnstructuredArray = null
-            }
-        };
-
-        var result = pendings.ToPendingDao();
-
-        Assert.Single(result);
-        Assert.Equal("Transaction description not available", result[0].RemittanceInformationUnstructured);
-        Assert.Single(result[0].RemittanceInformationUnstructuredArray);
     }
 }

--- a/BankoApi/Controllers/GoCardless/TransactionsController.cs
+++ b/BankoApi/Controllers/GoCardless/TransactionsController.cs
@@ -6,6 +6,7 @@ using BankoApi.Repository;
 using BankoApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace BankoApi.Controllers.GoCardless;
 
@@ -32,8 +33,13 @@ public class TransactionsController : ControllerBase
     {
         try
         {
+            var userId = User.GetUserId();
+
+            var ownsAccount = await _dbContext.BankAccounts
+                .AnyAsync(ba => ba.BankAccountId == bankAccountId.ToString() && ba.BankAuthorization.UserId == userId);
+            if (!ownsAccount) return Forbid();
+
             var transactions = await _goCardlessService.GetTransactionsAsync(bankAccountId);
-            Guid userId = User.GetUserId();
 
             if (transactions == null) return NotFound(FetchAndStoreTransactionResponse.NoTransactionsFound.ToString());
             await _repository.StoreTransactions(ctx: _dbContext, userId: userId, bankAccountId: bankAccountId, transactions);

--- a/BankoApi/Controllers/Settings/BankAccountController.cs
+++ b/BankoApi/Controllers/Settings/BankAccountController.cs
@@ -19,11 +19,13 @@ namespace BankoApi.Controllers.Settings
 
             try
             {
+                var userId = User.GetUserId();
                 List<BankAccountResponse> bankAccounts = new List<BankAccountResponse>();
 
                 foreach (var id in bankAccountId)
                 {
-                    var result = await _dbContext.BankAccounts.FirstOrDefaultAsync(ba => ba.BankAccountId == id)
+                    var result = await _dbContext.BankAccounts
+                            .FirstOrDefaultAsync(ba => ba.BankAccountId == id && ba.BankAuthorization.UserId == userId)
                             ?? throw new BankAccountNotFoundException(
                                 message: $"The requested BankAccountId: {bankAccountId} was not found.");
                     bankAccounts.Add(new BankAccountResponse() {
@@ -54,7 +56,13 @@ namespace BankoApi.Controllers.Settings
         [HttpPut("BankAccount")]
         public async Task<IActionResult> UpsertBankAccount([FromBody] UpsertBankAccountRequest request)
         {
-            var account = await _dbContext.BankAccounts.FirstOrDefaultAsync(a => a.BankAccountId == request.BankAccountId)
+            var userId = User.GetUserId();
+
+            var authorization = await _dbContext.BankAuthorizations
+                .FirstOrDefaultAsync(ba => ba.Id == request.BankAuthorizationId && ba.UserId == userId);
+            if (authorization == null) return Forbid();
+
+            var account = await _dbContext.BankAccounts.FirstOrDefaultAsync(a => a.BankAccountId == request.BankAccountId && a.BankAuthorization.UserId == userId)
                 ?? new BankAccount()
                 {
                     BankAccountId = request.BankAccountId,

--- a/BankoApi/Controllers/Settings/BankAuthorizationController.cs
+++ b/BankoApi/Controllers/Settings/BankAuthorizationController.cs
@@ -95,10 +95,7 @@ namespace BankoApi.Controllers.Settings
         [HttpPut("BankAuthorization")]
         public async Task<IActionResult> UpsertBankAuthorization([FromBody] UpsertBankAuthorizationRequest request)
         {
-            if (!_dbContext.Users.Where(x => x.UserId == request.UserId).Any())
-            {
-                return Unauthorized();
-            }
+            var userId = User.GetUserId();
 
             var authorization = await _dbContext.BankAuthorizations
                 .FirstOrDefaultAsync(ba => ba.AgreementId == request.AgreementId)
@@ -120,11 +117,12 @@ namespace BankoApi.Controllers.Settings
 
             if (authorization.Id == Guid.Empty)
             {
-                authorization.UserId = request.UserId;
+                authorization.UserId = userId;
                 _dbContext.BankAuthorizations.Add(authorization);
             }
             else
             {
+                if (authorization.UserId != userId) return Forbid();
                 authorization.UpdatedAt = DateTime.UtcNow;
             }
 

--- a/BankoApi/Controllers/Settings/ExpenseTagController.cs
+++ b/BankoApi/Controllers/Settings/ExpenseTagController.cs
@@ -10,15 +10,18 @@ namespace BankoApi.Controllers.Settings
         [HttpGet("expense-tags")]
         public async Task<IActionResult> GetAllTagsAsync()
         {
+            var userId = User.GetUserId();
             return Ok(new GetExpenseTagsResponse
             {
-                ExpenseTags = _dbContext.ExpenseTag.AsNoTracking().ToList()
+                ExpenseTags = _dbContext.ExpenseTag.AsNoTracking().Where(t => t.UserId == userId).ToList()
             });
         }
 
         [HttpPost("expense-tag")]
         public async Task<IActionResult> AddExpenseTagAsync([FromBody] ExpenseTag expenseTag)
         {
+            var userId = User.GetUserId();
+            expenseTag.UserId = userId;
             _dbContext.ExpenseTag.Add(expenseTag);
             await _dbContext.SaveChangesAsync();
             return Ok(new UpsertExpenseTagResponse { ExpenseTag = expenseTag });
@@ -27,8 +30,10 @@ namespace BankoApi.Controllers.Settings
         [HttpPut("expense-tag/{expenseTagId}")]
         public async Task<IActionResult> UpdateExpenseTagAsync(string expenseTagId, [FromBody] ExpenseTag expenseTag)
         {
+            var userId = User.GetUserId();
             var tag = _dbContext.ExpenseTag.Find(expenseTagId);
             if (tag == null) return NotFound();
+            if (tag.UserId != userId) return Forbid();
 
             tag.Name = expenseTag.Name;
             tag.Color = expenseTag.Color;
@@ -43,8 +48,10 @@ namespace BankoApi.Controllers.Settings
         [HttpDelete("expense-tag/{expenseTagId}")]
         public async Task<IActionResult> DeleteExpenseTagAsync(string expenseTagId)
         {
+            var userId = User.GetUserId();
             var tag = _dbContext.ExpenseTag.Find(expenseTagId);
             if (tag == null) return NotFound();
+            if (tag.UserId != userId) return Forbid();
             _dbContext.ExpenseTag.Remove(tag);
             await _dbContext.SaveChangesAsync();
 

--- a/BankoApi/Controllers/Settings/Requests/UpsertBankAuthorizationRequest.cs
+++ b/BankoApi/Controllers/Settings/Requests/UpsertBankAuthorizationRequest.cs
@@ -4,7 +4,6 @@ namespace BankoApi.Controllers.Settings.Requests
 {
     public class UpsertBankAuthorizationRequest
     {
-        public Guid UserId { get; set; }
         public BankAuthorizationStaus Status {  get; set; }
         public String? RequisitionId { get; set; }
         public String? InstitutionId { get; set; }

--- a/BankoApi/Controllers/Transactions/TransactionsController.cs
+++ b/BankoApi/Controllers/Transactions/TransactionsController.cs
@@ -34,21 +34,25 @@ public class TransactionsController : ControllerBase
         if (fromDate > toDate)
             return BadRequest("The fromDate cannot be greater than toDate.");
 
+        var userId = User.GetUserId();
+
         toDate ??= DateTime.UtcNow;
         fromDate ??= await _dbContext.Transactions
+            .Where(t => t.UserId == userId)
             .DefaultIfEmpty()
             .MinAsync(t => (DateTime?)t.BookingDate) ?? DateTime.UtcNow.AddYears(-1);
 
         var skip = (pageNumber - 1) * pageSize;
 
-        // Query filtered by date range
-        var query = _dbContext.Transactions.Where(t => t.BookingDate >= fromDate && t.BookingDate <= toDate);
+        // Query filtered by userId and date range
+        var query = _dbContext.Transactions.Where(t => t.UserId == userId && t.BookingDate >= fromDate && t.BookingDate <= toDate);
 
         var totalCount = query.Count();
 
         // First get just the IDs with pagination
         var transactionIds = await _dbContext.Transactions
-            .Where(t => t.isDeleted != true &&
+            .Where(t => t.UserId == userId &&
+                        t.isDeleted != true &&
                         t.BookingDate >= fromDate && 
                         t.BookingDate <= toDate)
             .OrderByDescending(t => t.BookingDate)
@@ -119,8 +123,10 @@ public class TransactionsController : ControllerBase
     [HttpDelete("{transactionId}")]
     public async Task<IActionResult> DeleteTransaction([FromRoute] string transactionId)
     {
+        var userId = User.GetUserId();
         var transaction = _dbContext.Transactions.Find(transactionId);
         if (transaction == null) return NotFound();
+        if (transaction.UserId != userId) return Forbid();
         transaction.isDeleted = true;
         await _dbContext.SaveChangesAsync();
         return Ok("Transaction updated");
@@ -129,8 +135,10 @@ public class TransactionsController : ControllerBase
     [HttpPut("expense-tag")]
     public async Task<IActionResult> UpdateExpenseTags([FromBody] UpdateExpenseTagRequest request)
     {
+        var userId = User.GetUserId();
         var transaction = _dbContext.Transactions.Find(request.TransactionId);
         if (transaction == null) return NotFound();
+        if (transaction.UserId != userId) return Forbid();
 
         if (request.ExpenseTagId != null)
         {
@@ -153,8 +161,10 @@ public class TransactionsController : ControllerBase
     [HttpPut("{transactionId}/note")]
     public async Task<IActionResult> UpdateNote([FromRoute] string transactionId, [FromBody] UpdateNoteRequest request)
     {
+        var userId = User.GetUserId();
         var transaction = _dbContext.Transactions.Find(transactionId);
         if (transaction == null) return NotFound();
+        if (transaction.UserId != userId) return Forbid();
         transaction.Note = request.Note;
         _dbContext.Entry(transaction).State = EntityState.Modified;
         await _dbContext.SaveChangesAsync();

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -17,7 +17,6 @@ public class BankoDbContext : DbContext
     public DbSet<DebtorAccount> DebtorAccounts { get; set; }
     public DbSet<BankAccount> BankAccounts { get; set; }
     public DbSet<BankAuthorization> BankAuthorizations { get; set; }
-    public DbSet<Pending> Pendings { get; set; }
     public DbSet<RefreshToken> RefreshTokens { get; set; }
     public DbSet<PrivacyPolicyVersion> PrivacyPolicyVersions { get; set; }
     public DbSet<ConsentLog> ConsentLogs { get; set; }

--- a/BankoApi/Data/Dao/ExpenseTag.cs
+++ b/BankoApi/Data/Dao/ExpenseTag.cs
@@ -3,6 +3,7 @@ namespace BankoApi.Data.Dao;
 public class ExpenseTag
 {
     public string Id { get; set; }
+    public Guid UserId { get; set; }
     public required string Name { get; set; }
     public required long Color { get; set; }
     public required bool isEarning { get; set; } = false;

--- a/BankoApi/Data/Dao/Transaction.cs
+++ b/BankoApi/Data/Dao/Transaction.cs
@@ -35,13 +35,3 @@ public class CreditorAccount
     public required string Iban { get; set; }
     public required string Bban { get; set; }
 }
-
-public class Pending
-{
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public required DateTime BookingDate { get; set; }
-    public required string Amount { get; set; }
-    public required string Currency { get; set; }
-    public required string RemittanceInformationUnstructured { get; set; }
-    public required List<string> RemittanceInformationUnstructuredArray { get; set; }
-}

--- a/BankoApi/Migrations/20260721095740_AddUserIdToExpenseTag.Designer.cs
+++ b/BankoApi/Migrations/20260721095740_AddUserIdToExpenseTag.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721095740_AddUserIdToExpenseTag")]
+    partial class AddUserIdToExpenseTag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260721095740_AddUserIdToExpenseTag.cs
+++ b/BankoApi/Migrations/20260721095740_AddUserIdToExpenseTag.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserIdToExpenseTag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Pendings");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "UserId",
+                table: "ExpenseTag",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "ExpenseTag");
+
+            migrationBuilder.CreateTable(
+                name: "Pendings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Amount = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    BookingDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Currency = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    RemittanceInformationUnstructured = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    RemittanceInformationUnstructuredArray = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Pendings", x => x.Id);
+                });
+        }
+    }
+}

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -5,7 +5,6 @@ using BankoApi.Services.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.Text.RegularExpressions;
-using PendingDto = BankoApi.Services.Model.Pending;
 
 namespace BankoApi.Repository;
 
@@ -13,8 +12,6 @@ public class TransactionsRepository
 {
     public async Task StoreTransactions(BankoDbContext ctx, Guid userId, Guid bankAccountId, Transactions transactions)
     {
-        UpdatePendingTransactions(ctx, transactions.BankTransactions.Pending);
-
         var transactionsToStore = (await DiscardDuplicates(dbContext:ctx, transactions: transactions))
                 .ToTransactionDao(dbContext: ctx, userId: userId, bankAccountId: bankAccountId)
                 .OrderByDescending(it => it.BookingDate);
@@ -26,6 +23,7 @@ public class TransactionsRepository
     {
         String agreementId = FindAgreementId(message);
         var result = dbContext.BankAuthorizations.FirstOrDefault(r => r.AgreementId == agreementId);
+        if (result == null) return;
         result.Status = Data.Dao.BankAuthorizationStaus.Expired;
         dbContext.SaveChanges();        
     }
@@ -36,14 +34,6 @@ public class TransactionsRepository
         Match match = Regex.Match(input, pattern);
 
         return match.Success ? match.Value : throw new EndUserAgreementException(FetchAndStoreTransactionResponse.AgreementIdNotFound.ToString());
-    }
-
-    private void UpdatePendingTransactions(BankoDbContext dbContext, List<PendingDto> pendings)
-    {
-        if (pendings.Count == 0) return;
-
-        dbContext.Pendings.RemoveRange();
-        dbContext.Pendings.AddRange(pendings.ToPendingDao());
     }
 
     private async Task<Transactions> DiscardDuplicates(BankoDbContext dbContext, Transactions transactions)
@@ -72,8 +62,7 @@ public class TransactionsRepository
         {
             BankTransactions = new BankTransactions
             {
-                Booked = new List<Booked>(),
-                Pending = new List<PendingDto>()
+                Booked = new List<Booked>()
             }
         };
         foreach (var newTransaction in transactions.BankTransactions.Booked)

--- a/BankoApi/Services/Model/Transactions.cs
+++ b/BankoApi/Services/Model/Transactions.cs
@@ -8,7 +8,6 @@ namespace BankoApi.Services.Model;
 using TransactionDao = Transaction;
 using DebtorAccountDao = Data.Dao.DebtorAccount;
 using CreditorAccountDao = Data.Dao.CreditorAccount;
-using PendingDao = Data.Dao.Pending;
 
 public class Transactions
 {
@@ -18,7 +17,6 @@ public class Transactions
 public class BankTransactions
 {
     public required List<Booked> Booked { get; set; }
-    public required List<Pending> Pending { get; set; }
 }
 
 public class Booked
@@ -80,14 +78,6 @@ public class CreditorAccount
     }
 }
 
-public class Pending
-{
-    public required string BookingDate { get; set; }
-    public required TransactionAmount TransactionAmount { get; set; }
-    public string? RemittanceInformationUnstructured { get; set; }
-    public List<string>? RemittanceInformationUnstructuredArray { get; set; }
-}
-
 public static class TransactionsExtensions
 {
     public static List<TransactionDao> ToTransactionDao(this Transactions transactions, BankoDbContext dbContext, Guid userId, Guid bankAccountId)
@@ -123,23 +113,6 @@ public static class TransactionsExtensions
                     : null,
                 RemittanceInformationStructuredArray = bookedTransaction.RemittanceInformationStructuredArray
             });
-    }
-
-    public static List<PendingDao> ToPendingDao(this List<Pending> pendings)
-    {
-        if (!pendings.Any())
-            return new List<PendingDao>();
-
-        return pendings.ConvertAll(pendingTransaction =>
-            new PendingDao
-            {
-                BookingDate = DateTime.Parse(pendingTransaction.BookingDate),
-                Amount = pendingTransaction.TransactionAmount.Amount,
-                Currency = pendingTransaction.TransactionAmount.Currency,
-                RemittanceInformationUnstructured = pendingTransaction?.RemittanceInformationUnstructured ?? "Transaction description not available",
-                RemittanceInformationUnstructuredArray = pendingTransaction?.RemittanceInformationUnstructuredArray ?? new List<string> { "Transaction description not available" }
-            }
-        );
     }
 
     private static DebtorAccountDao? GetDebtorAccountId(this DebtorAccount debtorAccount, BankoDbContext ctx)


### PR DESCRIPTION
## What

- Add UserId field to ExpenseTag so expense tags are scoped per user
- Remove unused Pending entity, DbSet, and Pendings table
- Filter all Transactions endpoints (GET/DELETE/PUT) by the authenticated user's UserId
- Filter all ExpenseTag endpoints (GET/POST/PUT/DELETE) by the authenticated user's UserId
- Filter BankAccount GET and UPSERT by verifying BankAuthorization ownership
- Use JWT UserId in UpsertBankAuthorization instead of trusting the request body
- Add bank account ownership check before GoCardless API calls in FetchAndStoreTransactions
- Add null check in SetEuaExpirationStatus to prevent NullReferenceException

## Why

- A new user with no bank linked could see transactions and data from other users on the homescreen
- The Pending entity was a write-only sink never read by any endpoint or frontend, adding unnecessary complexity and memory overhead
- Endpoints were returning data for all users instead of only the authenticated user, creating a cross-user data leakage vulnerability
- BankAccount and BankAuthorization endpoints had no ownership verification, allowing any authenticated user to access or modify another user's bank data
- UpsertBankAuthorization accepted UserId from the request body, allowing a user to impersonate another user
- GoCardless API was being called without verifying the requesting user owns the bank account, risking unauthorized external API calls
- SetEuaExpirationStatus could throw NullReferenceException when the agreement ID wasn't found in the database