### PR TITLE
fix: make refresh token rotation race-safe to prevent random logouts

### DIFF
--- a/BankoApi.Tests/Controllers/UsersControllerTests.cs
+++ b/BankoApi.Tests/Controllers/UsersControllerTests.cs
@@ -31,8 +31,8 @@ public class UsersControllerTests
     private UsersController CreateController(BankoDbContext ctx)
     {
         _tokenServiceMock
-            .Setup(t => t.GenerateTokens(It.IsAny<User>()))
-            .Returns(("test-access-token", "test-refresh-token", 900L));
+            .Setup(t => t.GenerateTokensAsync(It.IsAny<User>()))
+            .ReturnsAsync(("test-access-token", "test-refresh-token", 900L));
 
         return new UsersController(ctx, new UserRepository(), _tokenService, Mock.Of<ILogger<UsersController>>());
     }

--- a/BankoApi.Tests/Services/TokenServiceTests.cs
+++ b/BankoApi.Tests/Services/TokenServiceTests.cs
@@ -50,14 +50,14 @@ public class TokenServiceTests
     }
 
     [Fact]
-    public void GenerateTokens_ReturnsValidTokens()
+    public async Task GenerateTokens_ReturnsValidTokens()
     {
         using var ctx = CreateContext();
         var config = CreateConfig();
         var service = new TokenService(config, ctx);
         var user = CreateUser(ctx);
 
-        var (accessToken, refreshToken, expiresIn) = service.GenerateTokens(user);
+        var (accessToken, refreshToken, expiresIn) = await service.GenerateTokensAsync(user);
 
         Assert.NotEmpty(accessToken);
         Assert.NotEmpty(refreshToken);
@@ -71,14 +71,14 @@ public class TokenServiceTests
     }
 
     [Fact]
-    public void GenerateTokens_CreatesRefreshTokenInDb()
+    public async Task GenerateTokens_CreatesRefreshTokenInDb()
     {
         using var ctx = CreateContext();
         var config = CreateConfig();
         var service = new TokenService(config, ctx);
         var user = CreateUser(ctx);
 
-        service.GenerateTokens(user);
+        await service.GenerateTokensAsync(user);
 
         var storedToken = ctx.RefreshTokens.FirstOrDefault(rt => rt.UserId == user.UserId);
         Assert.NotNull(storedToken);
@@ -94,7 +94,7 @@ public class TokenServiceTests
         var config = CreateConfig();
         var service = new TokenService(config, ctx);
         var user = CreateUser(ctx);
-        var (_, originalRefresh, _) = service.GenerateTokens(user);
+        var (_, originalRefresh, _) = await service.GenerateTokensAsync(user);
 
         var (userId, accessToken, refreshToken, expiresIn) = await service.RefreshTokenAsync(originalRefresh);
 
@@ -136,14 +136,14 @@ public class TokenServiceTests
     }
 
     [Fact]
-    public async Task RefreshTokenAsync_UsedToken_RevokesAll()
+    public async Task RefreshTokenAsync_UsedToken_RevokesSingleTokenOnly()
     {
         using var ctx = CreateContext();
         var config = CreateConfig();
         var service = new TokenService(config, ctx);
         var user = CreateUser(ctx);
-        var (_, firstRefresh, _) = service.GenerateTokens(user);
-        var (_, secondRefresh, _) = service.GenerateTokens(user);
+        var (_, firstRefresh, _) = await service.GenerateTokensAsync(user);
+        var (_, secondRefresh, _) = await service.GenerateTokensAsync(user);
 
         var usedToken = ctx.RefreshTokens.First(rt => rt.Token == firstRefresh);
         usedToken.IsUsed = true;
@@ -152,8 +152,11 @@ public class TokenServiceTests
         await Assert.ThrowsAsync<SecurityTokenException>(() =>
             service.RefreshTokenAsync(firstRefresh));
 
-        var allTokens = ctx.RefreshTokens.Where(rt => rt.UserId == user.UserId).ToList();
-        Assert.All(allTokens, t => Assert.True(t.IsRevoked));
+        var revokedToken = ctx.RefreshTokens.First(rt => rt.Token == firstRefresh);
+        Assert.True(revokedToken.IsRevoked);
+
+        var otherToken = ctx.RefreshTokens.First(rt => rt.Token == secondRefresh);
+        Assert.False(otherToken.IsRevoked);
     }
 
     [Fact]
@@ -163,7 +166,7 @@ public class TokenServiceTests
         var config = CreateConfig();
         var service = new TokenService(config, ctx);
         var user = CreateUser(ctx);
-        var (_, refresh, _) = service.GenerateTokens(user);
+        var (_, refresh, _) = await service.GenerateTokensAsync(user);
 
         var storedToken = ctx.RefreshTokens.First(rt => rt.Token == refresh);
         storedToken.IsRevoked = true;
@@ -180,7 +183,7 @@ public class TokenServiceTests
         var config = CreateConfig();
         var service = new TokenService(config, ctx);
         var user = CreateUser(ctx);
-        var (_, refresh, _) = service.GenerateTokens(user);
+        var (_, refresh, _) = await service.GenerateTokensAsync(user);
 
         await service.RevokeRefreshTokenAsync(refresh);
 
@@ -199,7 +202,7 @@ public class TokenServiceTests
     }
 
     [Fact]
-    public void GenerateTokens_DefaultConfig_UsesDefaults()
+    public async Task GenerateTokens_DefaultConfig_UsesDefaults()
     {
         using var ctx = CreateContext();
         var config = new ConfigurationBuilder()
@@ -211,7 +214,7 @@ public class TokenServiceTests
         var service = new TokenService(config, ctx);
         var user = CreateUser(ctx);
 
-        var (accessToken, _, expiresIn) = service.GenerateTokens(user);
+        var (accessToken, _, expiresIn) = await service.GenerateTokensAsync(user);
 
         Assert.NotEmpty(accessToken);
         Assert.Equal(900L, expiresIn);

--- a/BankoApi/Controllers/Users/UsersController.cs
+++ b/BankoApi/Controllers/Users/UsersController.cs
@@ -56,7 +56,7 @@ public class UsersController : ControllerBase
             await _dbContext.SaveChangesAsync();
 
             var user = _dbContext.Users.Find(userId)!;
-            var (accessToken, refreshToken, expiresIn) = _tokenService.GenerateTokens(user);
+            var (accessToken, refreshToken, expiresIn) = await _tokenService.GenerateTokensAsync(user);
 
             return Ok(new UserResponse
             {
@@ -85,7 +85,7 @@ public class UsersController : ControllerBase
             var userId = _repository.ValidateAccount(_dbContext, request.Email, request.Password);
 
             var user = _dbContext.Users.Find(userId)!;
-            var (accessToken, refreshToken, expiresIn) = _tokenService.GenerateTokens(user);
+            var (accessToken, refreshToken, expiresIn) = await _tokenService.GenerateTokensAsync(user);
 
             return Ok(new UserResponse
             {

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -80,6 +80,8 @@ public class BankoDbContext : DbContext
         {
             entity.HasIndex(rt => rt.Token).IsUnique();
 
+            entity.Property(rt => rt.RowVersion).IsRowVersion();
+
             entity.HasOne(rt => rt.User)
                   .WithMany()
                   .HasForeignKey(rt => rt.UserId)

--- a/BankoApi/Data/Dao/RefreshToken.cs
+++ b/BankoApi/Data/Dao/RefreshToken.cs
@@ -18,6 +18,9 @@ public class RefreshToken
 
     [Required] public bool IsRevoked { get; set; }
 
+    [Timestamp]
+    public byte[] RowVersion { get; set; } = [];
+
     [Required] public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     [Required] public DateTime ExpiresAt { get; set; }

--- a/BankoApi/Repository/UserRepository.cs
+++ b/BankoApi/Repository/UserRepository.cs
@@ -54,7 +54,7 @@ public class UserRepository
         if (!isPasswordValid)
             throw new PasswordNotFoundException($"The password for the UserId {user.UserId} is not valid");
 
-        user.LastLoginAt = DateTime.Now;
+        user.LastLoginAt = DateTime.UtcNow;
         context.SaveChanges();
         
         return user!.UserId;

--- a/BankoApi/Services/TokenService.cs
+++ b/BankoApi/Services/TokenService.cs
@@ -5,6 +5,7 @@ using System.Text;
 using BankoApi.Data;
 using BankoApi.Data.Dao;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.IdentityModel.Tokens;
 
 namespace BankoApi.Services;
@@ -20,7 +21,7 @@ public class TokenService
         _context = context;
     }
 
-    public virtual (string accessToken, string refreshToken, long expiresIn) GenerateTokens(User user)
+    public virtual async Task<(string accessToken, string refreshToken, long expiresIn)> GenerateTokensAsync(User user)
     {
         var accessToken = GenerateAccessToken(user);
         var refreshToken = GenerateRefreshToken();
@@ -39,7 +40,7 @@ public class TokenService
         };
 
         _context.RefreshTokens.Add(refreshTokenEntity);
-        _context.SaveChanges();
+        await _context.SaveChangesAsync();
 
         return (accessToken, refreshToken, expiresIn);
     }
@@ -58,19 +59,38 @@ public class TokenService
 
         if (storedToken.IsUsed)
         {
-            RevokeUserTokens(storedToken.UserId);
+            RevokeSingleToken(storedToken);
             throw new SecurityTokenException("Refresh token is already used — possible token reuse detected");
         }
 
         if (storedToken.ExpiresAt < DateTime.UtcNow)
             throw new SecurityTokenException("Refresh token has expired");
 
+        IDbContextTransaction? transaction = null;
+        try
+        {
+            transaction = await _context.Database.BeginTransactionAsync();
+        }
+        catch (InvalidOperationException)
+        {
+            // Transactions not supported (e.g., in-memory test database)
+        }
+
         storedToken.IsUsed = true;
         _context.RefreshTokens.Update(storedToken);
         await _context.SaveChangesAsync();
 
-        var (accessToken, newRefreshToken, expiresIn) = GenerateTokens(storedToken.User);
-        return (storedToken.UserId, accessToken, newRefreshToken, expiresIn);
+        try
+        {
+            var (accessToken, newRefreshToken, expiresIn) = await GenerateTokensAsync(storedToken.User);
+            if (transaction != null) await transaction.CommitAsync();
+            return (storedToken.UserId, accessToken, newRefreshToken, expiresIn);
+        }
+        catch
+        {
+            if (transaction != null) await transaction.RollbackAsync();
+            throw;
+        }
     }
 
     public async Task RevokeRefreshTokenAsync(string refreshToken)
@@ -144,16 +164,10 @@ public class TokenService
             : 7;
     }
 
-    private void RevokeUserTokens(Guid userId)
+    private void RevokeSingleToken(RefreshToken token)
     {
-        var activeTokens = _context.RefreshTokens
-            .Where(rt => rt.UserId == userId && !rt.IsRevoked);
-        
-        foreach (var token in activeTokens)
-        {
-            token.IsRevoked = true;
-        }
-        
+        token.IsRevoked = true;
+        _context.RefreshTokens.Update(token);
         _context.SaveChanges();
     }
 }


### PR DESCRIPTION
## What

* Revoke only the reused refresh token instead of all active tokens for the user
* Wrap refresh token rotation (mark-used + issue new tokens) in a single atomic DB transaction
* Add optimistic concurrency via row versioning to the `RefreshToken` entity
* Migrate token generation to async and store the last-login timestamp as UTC
* Update tests and mocks to cover single-token revocation and the async API

## Why

* Concurrent refresh requests reusing the same token revoked every session for the user, causing random logouts
* A single transaction ensures the token is marked used and new tokens are issued atomically, preventing partial rotation on failure
* Row versioning lets the database reject stale concurrent updates instead of silently corrupting token state
* Async token generation aligns with the async request pipeline, and UTC timestamps avoid timezone-dependent bugs
* Tests now verify that only the reused token is revoked while other sessions remain valid