### PR TITLE
fix: add EF migration for RefreshToken row version column

### DIFF
--- a/BankoApi/Migrations/20260801102205_AddRowVersionToRefreshTokens.Designer.cs
+++ b/BankoApi/Migrations/20260801102205_AddRowVersionToRefreshTokens.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260801102205_AddRowVersionToRefreshTokens")]
+    partial class AddRowVersionToRefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260801102205_AddRowVersionToRefreshTokens.cs
+++ b/BankoApi/Migrations/20260801102205_AddRowVersionToRefreshTokens.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRowVersionToRefreshTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "RefreshTokens",
+                type: "rowversion",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "RefreshTokens");
+        }
+    }
+}


### PR DESCRIPTION
## What

* Add EF migration `20260801102205_AddRowVersionToRefreshTokens` creating the `RowVersion` rowversion column on `RefreshTokens`
* Update the EF model snapshot to reflect the new column

## Why

* The `RefreshToken` entity gained a `[Timestamp]` row-version property in #53, but the schema change was never migrated, causing runtime `Invalid column name 'RowVersion'` errors
* The updated snapshot keeps the model definition consistent so future migrations are generated against the correct schema