### PR TITLE
fix: upsert transactions and make refresh-token rotation retry-safe

### DIFF
--- a/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
@@ -74,17 +74,21 @@ public class TransactionsRepositoryTests
         await ctx.SaveChangesAsync();
 
         Assert.Equal(2, ctx.Transactions.Count());
+        Assert.All(ctx.Transactions, t => Assert.Equal(userId, t.UserId));
+        Assert.DoesNotContain(ctx.Users, u => u.Email == "default@example.com");
     }
 
     [Fact]
     public async Task StoreTransactions_DuplicateInternalTransactionId_SkipsDuplicates()
     {
         using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
         ctx.Transactions.Add(new Transaction
         {
             Id = "existing-tx",
-            UserId = Guid.NewGuid(),
-            BankAccountId = Guid.NewGuid(),
+            UserId = userId,
+            BankAccountId = bankAccountId,
             BookingDate = DateTime.UtcNow,
             ValueDate = DateTime.UtcNow,
             Amount = "50.00",
@@ -96,8 +100,6 @@ public class TransactionsRepositoryTests
         await ctx.SaveChangesAsync();
 
         var repo = new TransactionsRepository();
-        var userId = Guid.NewGuid();
-        var bankAccountId = Guid.NewGuid();
         var transactions = CreateSampleTransactions();
 
         await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
@@ -105,6 +107,45 @@ public class TransactionsRepositoryTests
 
         // Only tx-2 should be added (tx-1 has duplicate InternalTransactionId)
         Assert.Equal(2, ctx.Transactions.Count());
+        Assert.All(ctx.Transactions, t => Assert.Equal(userId, t.UserId));
+    }
+
+    [Fact]
+    public async Task StoreTransactions_DuplicateInternalTransactionId_UpdatesRowAndPreservesUserAnnotations()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        const string expenseTagId = "tag-1";
+
+        ctx.Transactions.Add(new Transaction
+        {
+            Id = "existing-tx",
+            UserId = userId,
+            BankAccountId = bankAccountId,
+            BookingDate = DateTime.UtcNow,
+            ValueDate = DateTime.UtcNow,
+            Amount = "50.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Existing",
+            RemittanceInformationUnstructuredArray = new List<string> { "Existing" },
+            InternalTransactionId = "internal-1",
+            ExpenseTagId = expenseTagId,
+            Note = "User note"
+        });
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var transactions = CreateSampleTransactions();
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var updated = ctx.Transactions.First(t => t.InternalTransactionId == "internal-1");
+        Assert.Equal("100.00", updated.Amount);
+        Assert.Equal(expenseTagId, updated.ExpenseTagId);
+        Assert.Equal("User note", updated.Note);
+        Assert.False(updated.isDeleted);
     }
 
     [Fact]

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -16,7 +16,7 @@ public class TransactionsRepository
 {
     public async Task StoreTransactions(BankoDbContext ctx, Guid userId, Guid bankAccountId, Transactions transactions)
     {
-        await UpdateExistingTransactions(ctx, transactions, bankAccountId);
+        await UpdateExistingTransactions(ctx, userId, transactions, bankAccountId);
         await ctx.SaveChangesAsync();
     }
 
@@ -37,7 +37,7 @@ public class TransactionsRepository
         return match.Success ? match.Value : throw new EndUserAgreementException(FetchAndStoreTransactionResponse.AgreementIdNotFound.ToString());
     }
 
-    private async Task UpdateExistingTransactions(BankoDbContext ctx, Transactions transactions, Guid bankAccountId)
+    private async Task UpdateExistingTransactions(BankoDbContext ctx, Guid userId, Transactions transactions, Guid bankAccountId)
     {
         foreach (var newTransaction in transactions.BankTransactions.Booked)
         {
@@ -57,7 +57,7 @@ public class TransactionsRepository
                 }
                 else
                 {
-                    CreateNewTransaction(ctx, newTransaction, bankAccountId);
+                    CreateNewTransaction(ctx, userId, newTransaction, bankAccountId);
                 }
             }
         }
@@ -75,8 +75,6 @@ public class TransactionsRepository
         existingTransaction.CreditorName = newTransaction.CreditorName;
         existingTransaction.DebtorName = newTransaction.DebtorName;
         existingTransaction.RemittanceInformationStructuredArray = newTransaction.RemittanceInformationStructuredArray;
-        existingTransaction.ExpenseTagId = null;
-        existingTransaction.Note = null;
         existingTransaction.isDeleted = false;
 
         if (newTransaction.DebtorAccount != null)
@@ -94,12 +92,12 @@ public class TransactionsRepository
         }
     }
 
-    private void CreateNewTransaction(BankoDbContext ctx, Booked newTransaction, Guid bankAccountId)
+    private void CreateNewTransaction(BankoDbContext ctx, Guid userId, Booked newTransaction, Guid bankAccountId)
     {
         var transaction = new Transaction
         {
             Id = newTransaction.TransactionId!,
-            UserId = GetCurrentUserId(ctx),
+            UserId = userId,
             BankAccountId = bankAccountId,
             BookingDate = DateTime.Parse(newTransaction.BookingDate),
             ValueDate = DateTime.Parse(newTransaction.ValueDate),
@@ -132,22 +130,6 @@ public class TransactionsRepository
         }
 
         ctx.Transactions.Add(transaction);
-    }
-
-    private Guid GetCurrentUserId(BankoDbContext ctx)
-    {
-        var userId = Guid.NewGuid();
-        var user = ctx.Users.FirstOrDefault(u => u.UserId == userId);
-        if (user == null)
-        {
-            user = new User
-            {
-                UserId = userId,
-                Email = "default@example.com"
-            };
-            ctx.Users.Add(user);
-        }
-        return user.UserId;
     }
 
     private BankoApi.Data.Dao.DebtorAccount GetOrCreateDebtorAccount(BankoDbContext ctx, BankoApi.Services.Model.DebtorAccount debtorAccount)

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -1,5 +1,6 @@
 using BankoApi.Controllers.GoCardless.Responses;
 using BankoApi.Data;
+using BankoApi.Data.Dao;
 using BankoApi.Exceptions.GoCardless.Transactions;
 using BankoApi.Services.Model;
 using Microsoft.EntityFrameworkCore;
@@ -8,15 +9,15 @@ using System.Text.RegularExpressions;
 
 namespace BankoApi.Repository;
 
+using CreditorAccountDao = BankoApi.Data.Dao.CreditorAccount;
+using DebtorAccountDao = BankoApi.Data.Dao.DebtorAccount;
+
 public class TransactionsRepository
 {
     public async Task StoreTransactions(BankoDbContext ctx, Guid userId, Guid bankAccountId, Transactions transactions)
     {
-        var transactionsToStore = (await DiscardDuplicates(dbContext:ctx, transactions: transactions))
-                .ToTransactionDao(dbContext: ctx, userId: userId, bankAccountId: bankAccountId)
-                .OrderByDescending(it => it.BookingDate);
-
-        ctx.Transactions.AddRange(transactionsToStore);
+        await UpdateExistingTransactions(ctx, transactions, bankAccountId);
+        await ctx.SaveChangesAsync();
     }
 
     public void SetEuaExpirationStatus(BankoDbContext dbContext, String message)
@@ -36,46 +37,131 @@ public class TransactionsRepository
         return match.Success ? match.Value : throw new EndUserAgreementException(FetchAndStoreTransactionResponse.AgreementIdNotFound.ToString());
     }
 
-    private async Task<Transactions> DiscardDuplicates(BankoDbContext dbContext, Transactions transactions)
+    private async Task UpdateExistingTransactions(BankoDbContext ctx, Transactions transactions, Guid bankAccountId)
     {
-        var candidateIds = transactions.BankTransactions.Booked
-            .SelectMany(t => new[] { t.InternalTransactionId, t.TransactionId })
-            .Where(id => !string.IsNullOrEmpty(id))
-            .Distinct()
-            .ToList();
-
-        var existingInternalIds = new HashSet<string>(await dbContext.Transactions
-            .AsNoTracking()
-            .Where(t => candidateIds.Contains(t.InternalTransactionId))
-            .Select(t => t.InternalTransactionId)
-            .ToListAsync());
-
-        var existingDbIds = new HashSet<string>(await dbContext.Transactions
-            .AsNoTracking()
-            .Where(t => candidateIds.Contains(t.Id))
-            .Select(t => t.Id)
-            .ToListAsync());
-
-        existingInternalIds.UnionWith(existingDbIds);
-
-        var transactionsToStore = new Transactions
-        {
-            BankTransactions = new BankTransactions
-            {
-                Booked = new List<Booked>()
-            }
-        };
         foreach (var newTransaction in transactions.BankTransactions.Booked)
-            
-            if (!existingInternalIds.Contains(newTransaction.InternalTransactionId) && !existingInternalIds.Contains(newTransaction.TransactionId))
+        {
+            if (string.IsNullOrEmpty(newTransaction.TransactionId))
             {
-                if (string.IsNullOrEmpty(newTransaction.TransactionId))
-                {
-                    newTransaction.TransactionId = Guid.NewGuid().ToString();
-                }
-                transactionsToStore.BankTransactions.Booked.Add(newTransaction);
-            }   
+                newTransaction.TransactionId = Guid.NewGuid().ToString();
+            }
 
-        return transactionsToStore;
+            if (!string.IsNullOrEmpty(newTransaction.InternalTransactionId))
+            {
+                var existingTransaction = await ctx.Transactions
+                    .FirstOrDefaultAsync(t => t.InternalTransactionId == newTransaction.InternalTransactionId);
+                
+                if (existingTransaction != null)
+                {
+                    UpdateTransactionData(ctx, existingTransaction, newTransaction);
+                }
+                else
+                {
+                    CreateNewTransaction(ctx, newTransaction, bankAccountId);
+                }
+            }
+        }
+    }
+
+    private void UpdateTransactionData(BankoDbContext ctx, Transaction existingTransaction, Booked newTransaction)
+    {
+        existingTransaction.BookingDate = DateTime.Parse(newTransaction.BookingDate);
+        existingTransaction.ValueDate = DateTime.Parse(newTransaction.ValueDate);
+        existingTransaction.Amount = newTransaction.TransactionAmount.Amount;
+        existingTransaction.Currency = newTransaction.TransactionAmount.Currency;
+        existingTransaction.RemittanceInformationUnstructured = newTransaction.RemittanceInformationUnstructured ?? "Transaction description not available";
+        existingTransaction.RemittanceInformationUnstructuredArray = newTransaction.RemittanceInformationUnstructuredArray ?? new List<string> { "Transaction description not available" };
+        existingTransaction.BankTransactionCode = newTransaction.BankTransactionCode;
+        existingTransaction.CreditorName = newTransaction.CreditorName;
+        existingTransaction.DebtorName = newTransaction.DebtorName;
+        existingTransaction.RemittanceInformationStructuredArray = newTransaction.RemittanceInformationStructuredArray;
+        existingTransaction.ExpenseTagId = null;
+        existingTransaction.Note = null;
+        existingTransaction.isDeleted = false;
+
+        if (newTransaction.DebtorAccount != null)
+        {
+            existingTransaction.DebtorAccount = GetOrCreateDebtorAccount(ctx, newTransaction.DebtorAccount);
+        }
+
+        if (newTransaction.CreditorAccount != null)
+        {
+            existingTransaction.CreditorAccount = new CreditorAccountDao
+            {
+                Bban = newTransaction.CreditorAccount.Bban,
+                Iban = newTransaction.CreditorAccount.Iban
+            };
+        }
+    }
+
+    private void CreateNewTransaction(BankoDbContext ctx, Booked newTransaction, Guid bankAccountId)
+    {
+        var transaction = new Transaction
+        {
+            Id = newTransaction.TransactionId!,
+            UserId = GetCurrentUserId(ctx),
+            BankAccountId = bankAccountId,
+            BookingDate = DateTime.Parse(newTransaction.BookingDate),
+            ValueDate = DateTime.Parse(newTransaction.ValueDate),
+            Amount = newTransaction.TransactionAmount.Amount,
+            Currency = newTransaction.TransactionAmount.Currency,
+            RemittanceInformationUnstructured = newTransaction.RemittanceInformationUnstructured ?? "Transaction description not available",
+            RemittanceInformationUnstructuredArray = newTransaction.RemittanceInformationUnstructuredArray ?? new List<string> { "Transaction description not available" },
+            BankTransactionCode = newTransaction.BankTransactionCode,
+            InternalTransactionId = newTransaction.InternalTransactionId,
+            CreditorName = newTransaction.CreditorName,
+            DebtorName = newTransaction.DebtorName,
+            RemittanceInformationStructuredArray = newTransaction.RemittanceInformationStructuredArray,
+            ExpenseTagId = null,
+            Note = null,
+            isDeleted = false
+        };
+
+        if (newTransaction.DebtorAccount != null)
+        {
+            transaction.DebtorAccount = GetOrCreateDebtorAccount(ctx, newTransaction.DebtorAccount);
+        }
+
+        if (newTransaction.CreditorAccount != null)
+        {
+            transaction.CreditorAccount = new CreditorAccountDao
+            {
+                Bban = newTransaction.CreditorAccount.Bban,
+                Iban = newTransaction.CreditorAccount.Iban
+            };
+        }
+
+        ctx.Transactions.Add(transaction);
+    }
+
+    private Guid GetCurrentUserId(BankoDbContext ctx)
+    {
+        var userId = Guid.NewGuid();
+        var user = ctx.Users.FirstOrDefault(u => u.UserId == userId);
+        if (user == null)
+        {
+            user = new User
+            {
+                UserId = userId,
+                Email = "default@example.com"
+            };
+            ctx.Users.Add(user);
+        }
+        return user.UserId;
+    }
+
+    private BankoApi.Data.Dao.DebtorAccount GetOrCreateDebtorAccount(BankoDbContext ctx, BankoApi.Services.Model.DebtorAccount debtorAccount)
+    {
+        var existingAccount = ctx.DebtorAccounts.FirstOrDefault(it => it.Iban == debtorAccount.Iban);
+        if (existingAccount != null) return existingAccount;
+
+        var newAccount = new BankoApi.Data.Dao.DebtorAccount
+        {
+            Bban = debtorAccount.Bban,
+            Iban = debtorAccount.Iban
+        };
+
+        ctx.DebtorAccounts.Add(newAccount);
+        return newAccount;
     }
 }

--- a/BankoApi/Services/ScheduledTaskService.cs
+++ b/BankoApi/Services/ScheduledTaskService.cs
@@ -79,7 +79,7 @@ public class ScheduledTaskService : BackgroundService
                     var transactions = await goCardlessService.GetTransactionsAsync(bankAccountId);
                     if (transactions != null)
                     {
-                        await repository.StoreTransactions(ctx: userDbContext, userId: userId, transactions: transactions, bankAccountId: bankAccountId);
+                        await repository.StoreTransactions(userDbContext, userId, bankAccountId, transactions);
                         await userDbContext.SaveChangesAsync();
                     }
                 }

--- a/BankoApi/Services/TokenService.cs
+++ b/BankoApi/Services/TokenService.cs
@@ -66,30 +66,44 @@ public class TokenService
         if (storedToken.ExpiresAt < DateTime.UtcNow)
             throw new SecurityTokenException("Refresh token has expired");
 
-        IDbContextTransaction? transaction = null;
+        return await ExecuteRefreshTransactionAsync(storedToken);
+    }
+
+    private async Task<(Guid userId, string accessToken, string refreshToken, long expiresIn)> ExecuteRefreshTransactionAsync(RefreshToken storedToken)
+    {
+        var executionStrategy = _context.Database.CreateExecutionStrategy();
+        return await executionStrategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await TryBeginTransactionAsync();
+
+            storedToken.IsUsed = true;
+            _context.RefreshTokens.Update(storedToken);
+            await _context.SaveChangesAsync();
+
+            try
+            {
+                var (accessToken, newRefreshToken, expiresIn) = await GenerateTokensAsync(storedToken.User);
+                if (transaction != null) await transaction.CommitAsync();
+                return (storedToken.UserId, accessToken, newRefreshToken, expiresIn);
+            }
+            catch
+            {
+                if (transaction != null) await transaction.RollbackAsync();
+                throw;
+            }
+        });
+    }
+
+    private async Task<IDbContextTransaction?> TryBeginTransactionAsync()
+    {
         try
         {
-            transaction = await _context.Database.BeginTransactionAsync();
+            return await _context.Database.BeginTransactionAsync();
         }
         catch (InvalidOperationException)
         {
             // Transactions not supported (e.g., in-memory test database)
-        }
-
-        storedToken.IsUsed = true;
-        _context.RefreshTokens.Update(storedToken);
-        await _context.SaveChangesAsync();
-
-        try
-        {
-            var (accessToken, newRefreshToken, expiresIn) = await GenerateTokensAsync(storedToken.User);
-            if (transaction != null) await transaction.CommitAsync();
-            return (storedToken.UserId, accessToken, newRefreshToken, expiresIn);
-        }
-        catch
-        {
-            if (transaction != null) await transaction.RollbackAsync();
-            throw;
+            return null;
         }
     }
 


### PR DESCRIPTION
## What

- Upsert GoCardless transactions by internal transaction ID, updating existing rows with fresh bank data instead of discarding them as duplicates.
- Attribute newly created transactions to the real user ID and preserve the user's expense tag and note on updated rows.
- Wrap refresh-token rotation in the EF retry execution strategy so user transactions work with SQL retries enabled.
- Strengthen repository tests to cover correct user attribution and preservation of user annotations.

## Why

- The daily transaction sync crashed with "An item with the same key has already been added" because re-fetched transactions were inserted rather than matched to already-stored rows.
- Prevents new transactions from being assigned to a placeholder user and stops the sync from wiping user-provided annotations, which was losing user data.
- `SaveChangesAsync` threw "SqlServerRetryingExecutionStrategy does not support user-initiated transactions", breaking the refresh-token flow when retries are enabled.
- Guards the fixes against regressions and documents the intended behavior.