### PR TITLE
fix: upsert bank authorization by user and institution instead of duplicating

### DIFF
--- a/BankoApi.Tests/Controllers/SettingsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/SettingsControllerTests.cs
@@ -784,6 +784,132 @@ public class SettingsControllerTests
     }
 
     [Fact]
+    public async Task UpsertEndUserAgreement_ExistingAuthorization_UpdatesInsteadOfDuplicating()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        var existingAuth = new BankAuthorization
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstitutionId = "TEST_BANK",
+            Status = BankAuthorizationStaus.Expired,
+            RequisitionId = "old-req",
+            AgreementId = "old-eua",
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-30)
+        };
+        ctx.BankAuthorizations.Add(existingAuth);
+        ctx.Users.Add(new User
+        {
+            UserId = userId,
+            Email = "test@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        ctx.SaveChanges();
+
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("agreements/enduser/") && r.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "new-eua",
+                        created = DateTime.UtcNow,
+                        institution_id = "TEST_BANK",
+                        max_historical_days = 30,
+                        access_valid_for_days = 30,
+                        access_scope = new[] { "balances", "transactions" },
+                        accepted = (DateTime?)null,
+                        reconfirmation = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("requisitions/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "new-req",
+                        created = DateTime.UtcNow,
+                        redirect = "Banko://bank-auth-callback",
+                        status = "CR",
+                        institution_id = "TEST_BANK",
+                        agreement = "new-eua",
+                        reference = "ref-updated",
+                        accounts = Array.Empty<string>(),
+                        user_language = "EN",
+                        link = "https://bank.link/req",
+                        ssn = "",
+                        account_selection = false,
+                        redirect_immediate = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("institutions/TEST_BANK/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = "TEST_BANK",
+                        name = "Test Bank",
+                        bic = "TESTBIC22",
+                        transaction_total_days = "180",
+                        countries = new[] { "GB" },
+                        logo = "https://example.com/logo.png",
+                        max_access_valid_for_days = "90"
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var controller = CreateController(ctx, service, userId: userId);
+        var request = new UpsertEndUserAgreementRequest
+        {
+            InstitutionId = "TEST_BANK",
+            DaysOfAccess = 30
+        };
+
+        var result = await controller.UpsertEndUserAgreement(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<UpsertEndUserAgreementResponse>(okResult.Value);
+        Assert.Equal(existingAuth.Id, response.BankAuthorizationId);
+
+        var saved = Assert.Single(ctx.BankAuthorizations);
+        Assert.Equal(existingAuth.Id, saved.Id);
+        Assert.Equal("new-req", saved.RequisitionId);
+        Assert.Equal("new-eua", saved.AgreementId);
+        Assert.Equal(BankAuthorizationStaus.Processing, saved.Status);
+    }
+
+    [Fact]
     public async Task GetBankAuthorization_WithAccounts_ReturnsNestedAccounts()
     {
         using var ctx = CreateContext();

--- a/BankoApi.Tests/Controllers/SettingsControllerTests.cs
+++ b/BankoApi.Tests/Controllers/SettingsControllerTests.cs
@@ -54,6 +54,102 @@ public class SettingsControllerTests
         return controller;
     }
 
+    private static User AddUser(BankoDbContext ctx, Guid userId)
+    {
+        var user = new User
+        {
+            UserId = userId,
+            Email = $"user-{userId:N}@example.com",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        ctx.Users.Add(user);
+        return user;
+    }
+
+    private static HttpMessageHandler CreateUpsertEndUserAgreementHandler(string institutionId, string euaId, string requisitionId)
+    {
+        var handlerMock = MockHelpers.CreateHandlerWithToken();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("agreements/enduser/") && r.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = euaId,
+                        created = DateTime.UtcNow,
+                        institution_id = institutionId,
+                        max_historical_days = 30,
+                        access_valid_for_days = 30,
+                        access_scope = new[] { "balances", "transactions" },
+                        accepted = (DateTime?)null,
+                        reconfirmation = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith("requisitions/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = requisitionId,
+                        created = DateTime.UtcNow,
+                        redirect = "Banko://bank-auth-callback",
+                        status = "CR",
+                        institution_id = institutionId,
+                        agreement = euaId,
+                        reference = "ref-1",
+                        accounts = Array.Empty<string>(),
+                        user_language = "EN",
+                        link = "https://bank.link/req",
+                        ssn = "",
+                        account_selection = false,
+                        redirect_immediate = false
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.AbsolutePath.EndsWith($"institutions/{institutionId}/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = institutionId,
+                        name = "Test Bank",
+                        bic = "TESTBIC22",
+                        transaction_total_days = "180",
+                        countries = new[] { "GB" },
+                        logo = "https://example.com/logo.png",
+                        max_access_valid_for_days = "90"
+                    },
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            });
+
+        return handlerMock.Object;
+    }
+
     [Fact]
     public async Task GetAllTagsAsync_HasTags_ReturnsTags()
     {
@@ -907,6 +1003,99 @@ public class SettingsControllerTests
         Assert.Equal("new-req", saved.RequisitionId);
         Assert.Equal("new-eua", saved.AgreementId);
         Assert.Equal(BankAuthorizationStaus.Processing, saved.Status);
+    }
+
+    [Fact]
+    public async Task UpsertEndUserAgreement_ReconnectingSameInstitution_KeepsSingleRow()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        AddUser(ctx, userId);
+        ctx.BankAuthorizations.Add(new BankAuthorization
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstitutionId = "TEST_BANK",
+            Status = BankAuthorizationStaus.Expired,
+            RequisitionId = "old-req",
+            AgreementId = "old-eua",
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-30)
+        });
+        ctx.SaveChanges();
+
+        var controller = CreateController(ctx,
+            MockHelpers.CreateGoCardlessServiceWithHandler(CreateUpsertEndUserAgreementHandler("TEST_BANK", "eua-1", "req-1")),
+            userId);
+        var request = new UpsertEndUserAgreementRequest { InstitutionId = "TEST_BANK", DaysOfAccess = 30 };
+
+        await controller.UpsertEndUserAgreement(request);
+        await controller.UpsertEndUserAgreement(request);
+
+        var saved = Assert.Single(ctx.BankAuthorizations);
+        Assert.Equal("req-1", saved.RequisitionId);
+        Assert.Equal("eua-1", saved.AgreementId);
+        Assert.Equal(BankAuthorizationStaus.Processing, saved.Status);
+    }
+
+    [Fact]
+    public async Task UpsertEndUserAgreement_SameUserDifferentInstitution_CreatesSeparateRows()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        AddUser(ctx, userId);
+        ctx.SaveChanges();
+
+        var controllerBank = CreateController(ctx,
+            MockHelpers.CreateGoCardlessServiceWithHandler(CreateUpsertEndUserAgreementHandler("TEST_BANK", "eua-bank", "req-bank")),
+            userId);
+        await controllerBank.UpsertEndUserAgreement(new UpsertEndUserAgreementRequest { InstitutionId = "TEST_BANK", DaysOfAccess = 30 });
+
+        var controllerOther = CreateController(ctx,
+            MockHelpers.CreateGoCardlessServiceWithHandler(CreateUpsertEndUserAgreementHandler("OTHER_BANK", "eua-other", "req-other")),
+            userId);
+        await controllerOther.UpsertEndUserAgreement(new UpsertEndUserAgreementRequest { InstitutionId = "OTHER_BANK", DaysOfAccess = 30 });
+
+        Assert.Equal(2, ctx.BankAuthorizations.Count());
+        Assert.Equal(new[] { "OTHER_BANK", "TEST_BANK" },
+            ctx.BankAuthorizations.Select(ba => ba.InstitutionId).OrderBy(i => i).ToArray());
+    }
+
+    [Fact]
+    public async Task UpsertEndUserAgreement_DifferentUserSameInstitution_CreatesSeparateRows()
+    {
+        using var ctx = CreateContext();
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        AddUser(ctx, userA);
+        AddUser(ctx, userB);
+        ctx.SaveChanges();
+
+        var controllerA = CreateController(ctx,
+            MockHelpers.CreateGoCardlessServiceWithHandler(CreateUpsertEndUserAgreementHandler("TEST_BANK", "eua-a", "req-a")),
+            userA);
+        await controllerA.UpsertEndUserAgreement(new UpsertEndUserAgreementRequest { InstitutionId = "TEST_BANK", DaysOfAccess = 30 });
+
+        var controllerB = CreateController(ctx,
+            MockHelpers.CreateGoCardlessServiceWithHandler(CreateUpsertEndUserAgreementHandler("TEST_BANK", "eua-b", "req-b")),
+            userB);
+        await controllerB.UpsertEndUserAgreement(new UpsertEndUserAgreementRequest { InstitutionId = "TEST_BANK", DaysOfAccess = 30 });
+
+        Assert.Equal(2, ctx.BankAuthorizations.Count());
+        Assert.Equal(2, ctx.BankAuthorizations.Select(ba => ba.UserId).Distinct().Count());
+    }
+
+    [Fact]
+    public void BankAuthorization_HasUniqueIndexOnUserAndInstitution()
+    {
+        using var ctx = CreateContext();
+        var entityType = ctx.Model.FindEntityType(typeof(BankAuthorization))!;
+
+        var index = entityType.GetIndexes().FirstOrDefault(i =>
+            i.Properties.Select(p => p.Name).SequenceEqual(new[] { nameof(BankAuthorization.UserId), nameof(BankAuthorization.InstitutionId) }));
+
+        Assert.NotNull(index);
+        Assert.True(index!.IsUnique);
     }
 
     [Fact]

--- a/BankoApi/Controllers/Settings/BankAuthorizationController.cs
+++ b/BankoApi/Controllers/Settings/BankAuthorizationController.cs
@@ -187,18 +187,22 @@ namespace BankoApi.Controllers.Settings
             );
 
             var userId = User.GetUserId();
-            var authorization = new BankAuthorization
-            {
-                UserId = userId,
-                RequisitionId = requisition.Id,
-                AgreementId = requisition.Agreement,
-                ReferenceId = requisition.Reference,
-                InstitutionId = requisition.InstitutionId,
-                InstitutionName = gcInstitution?.Name,
-                Status = BankAuthorizationStaus.Processing
-            };
+            var authorization = await _dbContext.BankAuthorizations
+                .FirstOrDefaultAsync(ba => ba.UserId == userId && ba.InstitutionId == institutionId)
+                ?? new BankAuthorization { UserId = userId };
 
-            _dbContext.BankAuthorizations.Add(authorization);
+            authorization.RequisitionId = requisition.Id;
+            authorization.AgreementId = requisition.Agreement;
+            authorization.ReferenceId = requisition.Reference;
+            authorization.InstitutionId = institutionId;
+            authorization.InstitutionName = gcInstitution?.Name;
+            authorization.Status = BankAuthorizationStaus.Processing;
+
+            if (authorization.Id == Guid.Empty)
+                _dbContext.BankAuthorizations.Add(authorization);
+            else
+                authorization.UpdatedAt = DateTime.UtcNow;
+
             await _dbContext.SaveChangesAsync();
 
             return Ok(new UpsertEndUserAgreementResponse()

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -130,6 +130,11 @@ public class BankoDbContext : DbContext
             entity.HasIndex(e => e.RequisitionId)
                   .IsUnique();
 
+            // One active bank connection per user and institution
+            entity.HasIndex(e => new { e.UserId, e.InstitutionId })
+                  .IsUnique()
+                  .HasDatabaseName("idx_bank_auth_user_institution");
+
             // Create an index on Status for querying connections that need action
             entity.HasIndex(e => e.Status)
                   .HasDatabaseName("idx_bank_auth_status");

--- a/BankoApi/Migrations/20260804204536_AddUniqueUserInstitutionIndex.Designer.cs
+++ b/BankoApi/Migrations/20260804204536_AddUniqueUserInstitutionIndex.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804204536_AddUniqueUserInstitutionIndex")]
+    partial class AddUniqueUserInstitutionIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260804204536_AddUniqueUserInstitutionIndex.cs
+++ b/BankoApi/Migrations/20260804204536_AddUniqueUserInstitutionIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUniqueUserInstitutionIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "idx_bank_auth_user_institution",
+                table: "BankAuthorizations",
+                columns: new[] { "UserId", "InstitutionId" },
+                unique: true,
+                filter: "[InstitutionId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_bank_auth_user_institution",
+                table: "BankAuthorizations");
+        }
+    }
+}


### PR DESCRIPTION
## What

- `UpsertEndUserAgreement` now looks up an existing bank authorization by `UserId + InstitutionId` and updates it in place, instead of always inserting a new row.
- Added a unique index on `(UserId, InstitutionId)` for `BankAuthorizations` via a new EF migration.
- Added tests covering the upsert behavior (update-in-place, no duplicates on reconnect, separate rows per user and per institution).

## Why

- Reconnecting an expired GoCardless agreement always minted a new requisition, so every reconnect inserted a duplicate row and left stale bank connections behind.
- GoCardless always returns a brand-new requisition id per `POST /requisitions`, so it cannot serve as the upsert key; `(UserId, InstitutionId)` is the natural key for "one connection per bank".
- The unique index enforces that invariant at the database level so duplicates cannot reappear.