### PR TITLE
fix: prevent duplicate transaction primary key crashes and dedup creditor accounts

### DIFF
--- a/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
@@ -2,7 +2,12 @@ using BankoApi.Data;
 using BankoApi.Data.Dao;
 using BankoApi.Repository;
 using BankoApi.Services.Model;
+using BankoApi.Tests.Utilities;
 using Microsoft.EntityFrameworkCore;
+using CreditorAccountDao = BankoApi.Data.Dao.CreditorAccount;
+using DebtorAccountDao = BankoApi.Data.Dao.DebtorAccount;
+using ServiceCreditorAccount = BankoApi.Services.Model.CreditorAccount;
+using ServiceDebtorAccount = BankoApi.Services.Model.DebtorAccount;
 
 namespace BankoApi.Tests.Repository;
 
@@ -218,5 +223,350 @@ public class TransactionsRepositoryTests
 
         Assert.Throws<BankoApi.Exceptions.GoCardless.Transactions.EndUserAgreementException>(
             () => repo.SetEuaExpirationStatus(ctx, "No GUID in this message"));
+    }
+
+    private static Booked CreateBooked(
+        string? transactionId,
+        string internalTransactionId,
+        string amount = "100.00",
+        string? creditorIban = null,
+        string? creditorBban = null,
+        string? debtorIban = null,
+        string? debtorBban = null)
+    {
+        return new Booked
+        {
+            TransactionId = transactionId,
+            BookingDate = "2024-01-15",
+            ValueDate = "2024-01-15",
+            TransactionAmount = new TransactionAmount
+            {
+                Amount = amount,
+                Currency = "EUR"
+            },
+            RemittanceInformationUnstructured = "Payment",
+            RemittanceInformationUnstructuredArray = new List<string> { "Payment" },
+            InternalTransactionId = internalTransactionId,
+            BankTransactionCode = "PMNT",
+            CreditorAccount = creditorIban != null
+                ? new ServiceCreditorAccount { Iban = creditorIban, Bban = creditorBban ?? "default-bban" }
+                : null,
+            DebtorAccount = debtorIban != null
+                ? new ServiceDebtorAccount { Iban = debtorIban, Bban = debtorBban ?? "default-bban" }
+                : null
+        };
+    }
+
+    private static Transaction CreateSeedTransaction(
+        Guid userId,
+        Guid bankAccountId,
+        string id,
+        string internalTransactionId,
+        DateTime bookingDate,
+        CreditorAccountDao? creditorAccount = null,
+        DebtorAccountDao? debtorAccount = null)
+    {
+        return new Transaction
+        {
+            Id = id,
+            UserId = userId,
+            BankAccountId = bankAccountId,
+            BookingDate = bookingDate,
+            ValueDate = bookingDate,
+            Amount = "50.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Existing",
+            RemittanceInformationUnstructuredArray = new List<string> { "Existing" },
+            InternalTransactionId = internalTransactionId,
+            CreditorAccount = creditorAccount,
+            DebtorAccount = debtorAccount,
+            isDeleted = false
+        };
+    }
+
+    [Fact]
+    public async Task StoreTransactions_NewCreditorAccount_CreatesNewRow()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(
+                        transactionId: "tx-1",
+                        internalTransactionId: "internal-1",
+                        creditorIban: "NO9386011117947",
+                        creditorBban: "93860111179")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        Assert.Single(ctx.CreditorAccounts);
+        var stored = ctx.Transactions.Single();
+        AccountAssertions.AssertEqual("NO9386011117947", "93860111179", stored.CreditorAccount);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_ExistingCreditorAccount_DiscardsChangeAndReusesRow()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var existingCreditor = new CreditorAccountDao
+        {
+            Iban = "NO9386011117947",
+            Bban = "original-bban"
+        };
+        ctx.Transactions.Add(CreateSeedTransaction(
+            userId, bankAccountId, "tx-1", "internal-1",
+            DateTime.Parse("2024-01-15"), creditorAccount: existingCreditor));
+        await ctx.SaveChangesAsync();
+        var seededCreditorId = existingCreditor.Id;
+
+        var repo = new TransactionsRepository();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(
+                        transactionId: "tx-1",
+                        internalTransactionId: "internal-1",
+                        creditorIban: "NO9386011117947",
+                        creditorBban: "changed-bban")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var storedCreditor = ctx.CreditorAccounts.Single();
+        Assert.Equal(seededCreditorId, storedCreditor.Id);
+        Assert.Equal("original-bban", storedCreditor.Bban);
+        var stored = ctx.Transactions.Single();
+        Assert.Equal(seededCreditorId, stored.CreditorAccount!.Id);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_ExistingTransactionWithNewCreditorIban_CreatesNewRow()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        ctx.Transactions.Add(CreateSeedTransaction(
+            userId, bankAccountId, "tx-1", "internal-1",
+            DateTime.Parse("2024-01-15"),
+            creditorAccount: new CreditorAccountDao { Iban = "NO9386011117947", Bban = "original-bban" }));
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(
+                        transactionId: "tx-1",
+                        internalTransactionId: "internal-1",
+                        creditorIban: "NO1234567890123",
+                        creditorBban: "12345678901")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        Assert.Equal(2, ctx.CreditorAccounts.Count());
+        var stored = ctx.Transactions.Single();
+        AccountAssertions.AssertEqual("NO1234567890123", "12345678901", stored.CreditorAccount);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_NewDebtorAccount_CreatesNewRow()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(
+                        transactionId: "tx-1",
+                        internalTransactionId: "internal-1",
+                        debtorIban: "DE89370400440532013000",
+                        debtorBban: "370400440532013000")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        Assert.Single(ctx.DebtorAccounts);
+        var stored = ctx.Transactions.Single();
+        AccountAssertions.AssertEqual("DE89370400440532013000", "370400440532013000", stored.DebtorAccount);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_ExistingDebtorAccount_DiscardsChangeAndReusesRow()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var existingDebtor = new DebtorAccountDao
+        {
+            Iban = "DE89370400440532013000",
+            Bban = "original-bban"
+        };
+        ctx.Transactions.Add(CreateSeedTransaction(
+            userId, bankAccountId, "tx-1", "internal-1",
+            DateTime.Parse("2024-01-15"), debtorAccount: existingDebtor));
+        await ctx.SaveChangesAsync();
+        var seededDebtorId = existingDebtor.Id;
+
+        var repo = new TransactionsRepository();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(
+                        transactionId: "tx-1",
+                        internalTransactionId: "internal-1",
+                        debtorIban: "DE89370400440532013000",
+                        debtorBban: "changed-bban")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var storedDebtor = ctx.DebtorAccounts.Single();
+        Assert.Equal(seededDebtorId, storedDebtor.Id);
+        Assert.Equal("original-bban", storedDebtor.Bban);
+        var stored = ctx.Transactions.Single();
+        Assert.Equal(seededDebtorId, stored.DebtorAccount!.Id);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_OnlyTransactionIdWithoutInternalId_StoresRow()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: "tx-9", internalTransactionId: "")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var stored = Assert.Single(ctx.Transactions);
+        Assert.Equal("tx-9", stored.Id);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_MissingTransactionIdAndInternalId_DiscardsTransaction()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: null, internalTransactionId: "")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        Assert.Empty(ctx.Transactions);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_ExistingTransactionMatchedByTransactionId_UpdatesRow()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        ctx.Transactions.Add(CreateSeedTransaction(
+            userId, bankAccountId, "tx-9", "",
+            DateTime.Parse("2024-01-15")));
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: "tx-9", internalTransactionId: "", amount: "200.00")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var stored = Assert.Single(ctx.Transactions);
+        Assert.Equal("200.00", stored.Amount);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_DuplicateInternalTransactionIdWithinBatch_StoresSingleRow()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: "tx-1", internalTransactionId: "duplicate-1"),
+                    CreateBooked(transactionId: "tx-2", internalTransactionId: "duplicate-1")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        Assert.Single(ctx.Transactions);
     }
 }

--- a/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
@@ -546,6 +546,125 @@ public class TransactionsRepositoryTests
     }
 
     [Fact]
+    public async Task StoreTransactions_ExistingTransactionWithEmptyInternalIdAndIncomingInternalId_UpdatesRow()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        ctx.Transactions.Add(CreateSeedTransaction(
+            userId, bankAccountId, "tx-1", "",
+            DateTime.Parse("2024-01-15")));
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: "tx-1", internalTransactionId: "internal-1", amount: "200.00")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var stored = Assert.Single(ctx.Transactions);
+        Assert.Equal("200.00", stored.Amount);
+        Assert.Equal("internal-1", stored.InternalTransactionId);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_ExistingTransactionOutsideBookingDateWindow_UpdatesRow()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        ctx.Transactions.Add(CreateSeedTransaction(
+            userId, bankAccountId, "tx-old", "",
+            DateTime.Parse("2020-01-01")));
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: "tx-old", internalTransactionId: "internal-new", amount: "200.00")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        var stored = Assert.Single(ctx.Transactions);
+        Assert.Equal("200.00", stored.Amount);
+        Assert.Equal("internal-new", stored.InternalTransactionId);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_ExistingTransactionIdInAnotherAccount_SkipsInsert()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        ctx.Transactions.Add(CreateSeedTransaction(
+            userId, accountA, "tx-1", "internal-1",
+            DateTime.Parse("2024-01-15")));
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: "tx-1", internalTransactionId: "internal-2", amount: "200.00")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, accountB, transactions);
+        await ctx.SaveChangesAsync();
+
+        var stored = Assert.Single(ctx.Transactions);
+        Assert.Equal(accountA, stored.BankAccountId);
+        Assert.Equal("50.00", stored.Amount);
+    }
+
+    [Fact]
+    public async Task StoreTransactions_DuplicateTransactionIdWithinBatch_DifferentInternalIds_StoresSingleRow()
+    {
+        using var ctx = CreateContext();
+        var repo = new TransactionsRepository();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        var transactions = new Transactions
+        {
+            BankTransactions = new BankTransactions
+            {
+                Booked = new List<Booked>
+                {
+                    CreateBooked(transactionId: "tx-1", internalTransactionId: "internal-a"),
+                    CreateBooked(transactionId: "tx-1", internalTransactionId: "internal-b")
+                }
+            }
+        };
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        Assert.Single(ctx.Transactions);
+    }
+
+    [Fact]
     public async Task StoreTransactions_DuplicateInternalTransactionIdWithinBatch_StoresSingleRow()
     {
         using var ctx = CreateContext();

--- a/BankoApi.Tests/Services/GoCardlessServiceTests.cs
+++ b/BankoApi.Tests/Services/GoCardlessServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using BankoApi.Exceptions.GoCardless.Transactions;
 using BankoApi.Services;
@@ -139,6 +140,78 @@ public class GoCardlessServiceTests
         {
             callCount++;
             return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            service.GetTransactionsAsync(accountId));
+        Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_TooManyRequestsThenSuccess_RetriesAndReturnsTransactions()
+    {
+        var accountId = Guid.NewGuid();
+        var transactionsResponse = new
+        {
+            transactions = new
+            {
+                booked = new[]
+                {
+                    new
+                    {
+                        transactionId = "tx-1",
+                        bookingDate = "2024-01-15",
+                        valueDate = "2024-01-15",
+                        transactionAmount = new { amount = "100.00", currency = "EUR" },
+                        remittanceInformationUnstructured = "Test payment",
+                        remittanceInformationUnstructuredArray = new[] { "Test payment" },
+                        internalTransactionId = "internal-1",
+                        bankTransactionCode = "PMNT"
+                    }
+                },
+                pending = Array.Empty<object>()
+            }
+        };
+
+        var callCount = 0;
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+        {
+            callCount++;
+            if (callCount == 1)
+                return new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                {
+                    Headers = { RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(0)) }
+                };
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(transactionsResponse,
+                    new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+            };
+        });
+
+        var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);
+        var result = await service.GetTransactionsAsync(accountId);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, callCount);
+        Assert.Single(result.BankTransactions.Booked);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_TooManyRequestsExhausted_ThrowsException()
+    {
+        var accountId = Guid.NewGuid();
+        var callCount = 0;
+        var handlerMock = MockHelpers.CreateHandlerWithToken(_ =>
+        {
+            callCount++;
+            return new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Headers = { RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(0)) }
+            };
         });
 
         var service = MockHelpers.CreateGoCardlessServiceWithHandler(handlerMock.Object);

--- a/BankoApi.Tests/Utilities/AccountAssertions.cs
+++ b/BankoApi.Tests/Utilities/AccountAssertions.cs
@@ -1,0 +1,19 @@
+using BankoApi.Data.Dao;
+using Xunit;
+
+namespace BankoApi.Tests.Utilities;
+
+public static class AccountAssertions
+{
+    public static void AssertEqual(string iban, string bban, CreditorAccount? actual)
+        => AssertCore(iban, bban, actual?.Iban, actual?.Bban);
+
+    public static void AssertEqual(string iban, string bban, DebtorAccount? actual)
+        => AssertCore(iban, bban, actual?.Iban, actual?.Bban);
+
+    private static void AssertCore(string iban, string bban, string? actualIban, string? actualBban)
+    {
+        Assert.Equal(iban, actualIban);
+        Assert.Equal(bban, actualBban);
+    }
+}

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -15,6 +15,7 @@ public class BankoDbContext : DbContext
     public DbSet<Transaction> Transactions { get; set; }
     public DbSet<ExpenseTag> ExpenseTag { get; set; }
     public DbSet<DebtorAccount> DebtorAccounts { get; set; }
+    public DbSet<CreditorAccount> CreditorAccounts { get; set; }
     public DbSet<BankAccount> BankAccounts { get; set; }
     public DbSet<BankAuthorization> BankAuthorizations { get; set; }
     public DbSet<RefreshToken> RefreshTokens { get; set; }

--- a/BankoApi/Migrations/20260806102543_RenameCreditorAccountTableToCreditorAccounts.Designer.cs
+++ b/BankoApi/Migrations/20260806102543_RenameCreditorAccountTableToCreditorAccounts.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806102543_RenameCreditorAccountTableToCreditorAccounts")]
+    partial class RenameCreditorAccountTableToCreditorAccounts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260806102543_RenameCreditorAccountTableToCreditorAccounts.cs
+++ b/BankoApi/Migrations/20260806102543_RenameCreditorAccountTableToCreditorAccounts.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameCreditorAccountTableToCreditorAccounts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Transactions_CreditorAccount_CreditorAccountId",
+                table: "Transactions");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CreditorAccount",
+                table: "CreditorAccount");
+
+            migrationBuilder.RenameTable(
+                name: "CreditorAccount",
+                newName: "CreditorAccounts");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_CreditorAccount_Iban",
+                table: "CreditorAccounts",
+                newName: "IX_CreditorAccounts_Iban");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CreditorAccounts",
+                table: "CreditorAccounts",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Transactions_CreditorAccounts_CreditorAccountId",
+                table: "Transactions",
+                column: "CreditorAccountId",
+                principalTable: "CreditorAccounts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Transactions_CreditorAccounts_CreditorAccountId",
+                table: "Transactions");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CreditorAccounts",
+                table: "CreditorAccounts");
+
+            migrationBuilder.RenameTable(
+                name: "CreditorAccounts",
+                newName: "CreditorAccount");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_CreditorAccounts_Iban",
+                table: "CreditorAccount",
+                newName: "IX_CreditorAccount_Iban");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CreditorAccount",
+                table: "CreditorAccount",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Transactions_CreditorAccount_CreditorAccountId",
+                table: "Transactions",
+                column: "CreditorAccountId",
+                principalTable: "CreditorAccount",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -4,6 +4,7 @@ using BankoApi.Data.Dao;
 using BankoApi.Exceptions.GoCardless.Transactions;
 using BankoApi.Services.Model;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using System.Text.RegularExpressions;
 
@@ -15,6 +16,13 @@ using DebtorAccountDao = BankoApi.Data.Dao.DebtorAccount;
 public class TransactionsRepository
 {
     private const int SaveBatchSize = 200;
+
+    private readonly ILogger<TransactionsRepository>? _logger;
+
+    public TransactionsRepository(ILogger<TransactionsRepository>? logger = null)
+    {
+        _logger = logger;
+    }
 
     public async Task StoreTransactions(BankoDbContext ctx, Guid userId, Guid bankAccountId, Transactions transactions)
     {
@@ -29,15 +37,22 @@ public class TransactionsRepository
                 && t.BookingDate >= oldestBookingDate.AddDays(-1))
             .ToListAsync();
 
-        var existingByKey = new Dictionary<string, Transaction>();
+        var existingById = new Dictionary<string, Transaction>();
+        var existingByInternalId = new Dictionary<string, Transaction>();
         foreach (var transaction in existingTransactions)
         {
-            existingByKey.TryAdd(GetMatchKey(transaction), transaction);
+            existingById.TryAdd(transaction.Id, transaction);
+            if (!string.IsNullOrEmpty(transaction.InternalTransactionId))
+            {
+                existingByInternalId.TryAdd(transaction.InternalTransactionId, transaction);
+            }
         }
 
         var creditorByIban = new Dictionary<string, CreditorAccountDao>();
         var debtorByIban = new Dictionary<string, DebtorAccountDao>();
-        var seenKeys = new HashSet<string>();
+        var seenTransactionIds = new HashSet<string>();
+        var seenInternalIds = new HashSet<string>();
+        var plannedInserts = new List<(Booked Booked, string Id)>();
         var pendingTransactions = new List<Transaction>();
 
         foreach (var newTransaction in booked)
@@ -49,35 +64,94 @@ public class TransactionsRepository
             if (string.IsNullOrEmpty(id) && string.IsNullOrEmpty(newTransaction.InternalTransactionId))
                 continue;
 
-            var key = GetMatchKey(newTransaction, id!);
-            if (!seenKeys.Add(key)) continue;
+            if (!seenTransactionIds.Add(id!)) continue;
+            if (!string.IsNullOrEmpty(newTransaction.InternalTransactionId)
+                && !seenInternalIds.Add(newTransaction.InternalTransactionId))
+                continue;
 
-            if (existingByKey.TryGetValue(key, out var existingTransaction))
+            var existingTransaction = FindExistingTransaction(existingById, existingByInternalId, id!, newTransaction.InternalTransactionId);
+            if (existingTransaction != null)
             {
+                BackfillInternalTransactionId(existingTransaction, newTransaction);
                 UpdateTransactionData(ctx, existingTransaction, newTransaction, creditorByIban, debtorByIban);
             }
             else
             {
-                pendingTransactions.Add(
-                    CreateNewTransaction(ctx, userId, newTransaction, bankAccountId, id!, creditorByIban, debtorByIban));
+                plannedInserts.Add((newTransaction, id!));
             }
         }
 
+        await ResolvePlannedInserts(ctx, plannedInserts, pendingTransactions, userId, bankAccountId, creditorByIban, debtorByIban);
         await SaveInBatches(ctx, pendingTransactions);
     }
 
-    private static string GetMatchKey(Transaction transaction)
+    private static Transaction? FindExistingTransaction(
+        Dictionary<string, Transaction> existingById,
+        Dictionary<string, Transaction> existingByInternalId,
+        string id,
+        string internalTransactionId)
     {
-        return string.IsNullOrEmpty(transaction.InternalTransactionId)
-            ? transaction.Id
-            : transaction.InternalTransactionId;
+        if (!string.IsNullOrEmpty(internalTransactionId)
+            && existingByInternalId.TryGetValue(internalTransactionId, out var byInternalId))
+        {
+            return byInternalId;
+        }
+
+        return existingById.TryGetValue(id, out var byId) ? byId : null;
     }
 
-    private static string GetMatchKey(Booked booked, string id)
+    private static void BackfillInternalTransactionId(Transaction existingTransaction, Booked newTransaction)
     {
-        return string.IsNullOrEmpty(booked.InternalTransactionId)
-            ? id
-            : booked.InternalTransactionId;
+        if (string.IsNullOrEmpty(existingTransaction.InternalTransactionId)
+            && !string.IsNullOrEmpty(newTransaction.InternalTransactionId))
+        {
+            existingTransaction.InternalTransactionId = newTransaction.InternalTransactionId;
+        }
+    }
+
+    private async Task ResolvePlannedInserts(
+        BankoDbContext ctx,
+        List<(Booked Booked, string Id)> plannedInserts,
+        List<Transaction> pendingTransactions,
+        Guid userId,
+        Guid bankAccountId,
+        Dictionary<string, CreditorAccountDao> creditorByIban,
+        Dictionary<string, DebtorAccountDao> debtorByIban)
+    {
+        if (plannedInserts.Count == 0) return;
+
+        var insertIds = plannedInserts.Select(p => p.Id).ToList();
+        var existingById = await ctx.Transactions
+            .Where(t => insertIds.Contains(t.Id))
+            .ToDictionaryAsync(t => t.Id);
+
+        foreach (var planned in plannedInserts.ToList())
+        {
+            if (!existingById.TryGetValue(planned.Id, out var existingTransaction))
+                continue;
+
+            plannedInserts.Remove(planned);
+            if (existingTransaction.UserId == userId && existingTransaction.BankAccountId == bankAccountId)
+            {
+                _logger?.LogWarning(
+                    "Transaction {Id} already exists but was outside the booking-date lookup window; updating instead of inserting",
+                    planned.Id);
+                BackfillInternalTransactionId(existingTransaction, planned.Booked);
+                UpdateTransactionData(ctx, existingTransaction, planned.Booked, creditorByIban, debtorByIban);
+            }
+            else
+            {
+                _logger?.LogWarning(
+                    "Transaction {Id} already exists under a different bank account; skipping insert to avoid a duplicate primary key",
+                    planned.Id);
+            }
+        }
+
+        foreach (var planned in plannedInserts)
+        {
+            pendingTransactions.Add(
+                CreateNewTransaction(ctx, userId, planned.Booked, bankAccountId, planned.Id, creditorByIban, debtorByIban));
+        }
     }
 
     private async Task SaveInBatches(BankoDbContext ctx, List<Transaction> pendingTransactions)

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -14,10 +14,80 @@ using DebtorAccountDao = BankoApi.Data.Dao.DebtorAccount;
 
 public class TransactionsRepository
 {
+    private const int SaveBatchSize = 200;
+
     public async Task StoreTransactions(BankoDbContext ctx, Guid userId, Guid bankAccountId, Transactions transactions)
     {
-        await UpdateExistingTransactions(ctx, userId, transactions, bankAccountId);
-        await ctx.SaveChangesAsync();
+        var booked = transactions.BankTransactions.Booked;
+        if (booked.Count == 0) return;
+
+        var oldestBookingDate = booked.Min(t => DateTime.Parse(t.BookingDate));
+
+        var existingTransactions = await ctx.Transactions
+            .Where(t => t.UserId == userId
+                && t.BankAccountId == bankAccountId
+                && t.BookingDate >= oldestBookingDate.AddDays(-1))
+            .ToListAsync();
+
+        var existingByKey = new Dictionary<string, Transaction>();
+        foreach (var transaction in existingTransactions)
+        {
+            existingByKey.TryAdd(GetMatchKey(transaction), transaction);
+        }
+
+        var creditorByIban = new Dictionary<string, CreditorAccountDao>();
+        var debtorByIban = new Dictionary<string, DebtorAccountDao>();
+        var seenKeys = new HashSet<string>();
+        var pendingTransactions = new List<Transaction>();
+
+        foreach (var newTransaction in booked)
+        {
+            string? id = newTransaction.TransactionId;
+            if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(newTransaction.InternalTransactionId))
+                id = Guid.NewGuid().ToString();
+
+            if (string.IsNullOrEmpty(id) && string.IsNullOrEmpty(newTransaction.InternalTransactionId))
+                continue;
+
+            var key = GetMatchKey(newTransaction, id!);
+            if (!seenKeys.Add(key)) continue;
+
+            if (existingByKey.TryGetValue(key, out var existingTransaction))
+            {
+                UpdateTransactionData(ctx, existingTransaction, newTransaction, creditorByIban, debtorByIban);
+            }
+            else
+            {
+                pendingTransactions.Add(
+                    CreateNewTransaction(ctx, userId, newTransaction, bankAccountId, id!, creditorByIban, debtorByIban));
+            }
+        }
+
+        await SaveInBatches(ctx, pendingTransactions);
+    }
+
+    private static string GetMatchKey(Transaction transaction)
+    {
+        return string.IsNullOrEmpty(transaction.InternalTransactionId)
+            ? transaction.Id
+            : transaction.InternalTransactionId;
+    }
+
+    private static string GetMatchKey(Booked booked, string id)
+    {
+        return string.IsNullOrEmpty(booked.InternalTransactionId)
+            ? id
+            : booked.InternalTransactionId;
+    }
+
+    private async Task SaveInBatches(BankoDbContext ctx, List<Transaction> pendingTransactions)
+    {
+        for (var i = 0; i < pendingTransactions.Count; i += SaveBatchSize)
+        {
+            var batch = pendingTransactions.Skip(i).Take(SaveBatchSize);
+            ctx.Transactions.AddRange(batch);
+            await ctx.SaveChangesAsync();
+        }
     }
 
     public void SetEuaExpirationStatus(BankoDbContext dbContext, String message)
@@ -37,33 +107,12 @@ public class TransactionsRepository
         return match.Success ? match.Value : throw new EndUserAgreementException(FetchAndStoreTransactionResponse.AgreementIdNotFound.ToString());
     }
 
-    private async Task UpdateExistingTransactions(BankoDbContext ctx, Guid userId, Transactions transactions, Guid bankAccountId)
-    {
-        foreach (var newTransaction in transactions.BankTransactions.Booked)
-        {
-            if (string.IsNullOrEmpty(newTransaction.TransactionId))
-            {
-                newTransaction.TransactionId = Guid.NewGuid().ToString();
-            }
-
-            if (!string.IsNullOrEmpty(newTransaction.InternalTransactionId))
-            {
-                var existingTransaction = await ctx.Transactions
-                    .FirstOrDefaultAsync(t => t.InternalTransactionId == newTransaction.InternalTransactionId);
-                
-                if (existingTransaction != null)
-                {
-                    UpdateTransactionData(ctx, existingTransaction, newTransaction);
-                }
-                else
-                {
-                    CreateNewTransaction(ctx, userId, newTransaction, bankAccountId);
-                }
-            }
-        }
-    }
-
-    private void UpdateTransactionData(BankoDbContext ctx, Transaction existingTransaction, Booked newTransaction)
+    private void UpdateTransactionData(
+        BankoDbContext ctx,
+        Transaction existingTransaction,
+        Booked newTransaction,
+        Dictionary<string, CreditorAccountDao> creditorByIban,
+        Dictionary<string, DebtorAccountDao> debtorByIban)
     {
         existingTransaction.BookingDate = DateTime.Parse(newTransaction.BookingDate);
         existingTransaction.ValueDate = DateTime.Parse(newTransaction.ValueDate);
@@ -79,24 +128,27 @@ public class TransactionsRepository
 
         if (newTransaction.DebtorAccount != null)
         {
-            existingTransaction.DebtorAccount = GetOrCreateDebtorAccount(ctx, newTransaction.DebtorAccount);
+            existingTransaction.DebtorAccount = GetOrCreateDebtorAccount(ctx, newTransaction.DebtorAccount, debtorByIban);
         }
 
         if (newTransaction.CreditorAccount != null)
         {
-            existingTransaction.CreditorAccount = new CreditorAccountDao
-            {
-                Bban = newTransaction.CreditorAccount.Bban,
-                Iban = newTransaction.CreditorAccount.Iban
-            };
+            existingTransaction.CreditorAccount = GetOrCreateCreditorAccount(ctx, newTransaction.CreditorAccount, creditorByIban);
         }
     }
 
-    private void CreateNewTransaction(BankoDbContext ctx, Guid userId, Booked newTransaction, Guid bankAccountId)
+    private Transaction CreateNewTransaction(
+        BankoDbContext ctx,
+        Guid userId,
+        Booked newTransaction,
+        Guid bankAccountId,
+        string id,
+        Dictionary<string, CreditorAccountDao> creditorByIban,
+        Dictionary<string, DebtorAccountDao> debtorByIban)
     {
         var transaction = new Transaction
         {
-            Id = newTransaction.TransactionId!,
+            Id = id,
             UserId = userId,
             BankAccountId = bankAccountId,
             BookingDate = DateTime.Parse(newTransaction.BookingDate),
@@ -117,33 +169,58 @@ public class TransactionsRepository
 
         if (newTransaction.DebtorAccount != null)
         {
-            transaction.DebtorAccount = GetOrCreateDebtorAccount(ctx, newTransaction.DebtorAccount);
+            transaction.DebtorAccount = GetOrCreateDebtorAccount(ctx, newTransaction.DebtorAccount, debtorByIban);
         }
 
         if (newTransaction.CreditorAccount != null)
         {
-            transaction.CreditorAccount = new CreditorAccountDao
-            {
-                Bban = newTransaction.CreditorAccount.Bban,
-                Iban = newTransaction.CreditorAccount.Iban
-            };
+            transaction.CreditorAccount = GetOrCreateCreditorAccount(ctx, newTransaction.CreditorAccount, creditorByIban);
         }
 
-        ctx.Transactions.Add(transaction);
+        return transaction;
     }
 
-    private BankoApi.Data.Dao.DebtorAccount GetOrCreateDebtorAccount(BankoDbContext ctx, BankoApi.Services.Model.DebtorAccount debtorAccount)
+    private BankoApi.Data.Dao.DebtorAccount GetOrCreateDebtorAccount(
+        BankoDbContext ctx,
+        BankoApi.Services.Model.DebtorAccount debtorAccount,
+        Dictionary<string, BankoApi.Data.Dao.DebtorAccount> debtorByIban)
     {
+        if (debtorByIban.TryGetValue(debtorAccount.Iban, out var cached)) return cached;
+
         var existingAccount = ctx.DebtorAccounts.FirstOrDefault(it => it.Iban == debtorAccount.Iban);
-        if (existingAccount != null) return existingAccount;
-
-        var newAccount = new BankoApi.Data.Dao.DebtorAccount
+        if (existingAccount == null)
         {
-            Bban = debtorAccount.Bban,
-            Iban = debtorAccount.Iban
-        };
+            existingAccount = new BankoApi.Data.Dao.DebtorAccount
+            {
+                Bban = debtorAccount.Bban,
+                Iban = debtorAccount.Iban
+            };
+            ctx.DebtorAccounts.Add(existingAccount);
+        }
 
-        ctx.DebtorAccounts.Add(newAccount);
-        return newAccount;
+        debtorByIban[debtorAccount.Iban] = existingAccount;
+        return existingAccount;
+    }
+
+    private BankoApi.Data.Dao.CreditorAccount GetOrCreateCreditorAccount(
+        BankoDbContext ctx,
+        BankoApi.Services.Model.CreditorAccount creditorAccount,
+        Dictionary<string, BankoApi.Data.Dao.CreditorAccount> creditorByIban)
+    {
+        if (creditorByIban.TryGetValue(creditorAccount.Iban, out var cached)) return cached;
+
+        var existingAccount = ctx.CreditorAccounts.FirstOrDefault(it => it.Iban == creditorAccount.Iban);
+        if (existingAccount == null)
+        {
+            existingAccount = new BankoApi.Data.Dao.CreditorAccount
+            {
+                Bban = creditorAccount.Bban,
+                Iban = creditorAccount.Iban
+            };
+            ctx.CreditorAccounts.Add(existingAccount);
+        }
+
+        creditorByIban[creditorAccount.Iban] = existingAccount;
+        return existingAccount;
     }
 }

--- a/BankoApi/Services/GoCardlessService.cs
+++ b/BankoApi/Services/GoCardlessService.cs
@@ -10,11 +10,13 @@ public class GoCardlessService
 {
     private const int MaxRetries = 3;
     private static readonly TimeSpan RetryBaseDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
     private static readonly HashSet<HttpStatusCode> TransientStatusCodes = new()
     {
         HttpStatusCode.BadGateway,
         HttpStatusCode.ServiceUnavailable,
-        HttpStatusCode.GatewayTimeout
+        HttpStatusCode.GatewayTimeout,
+        HttpStatusCode.TooManyRequests
     };
 
     private readonly HttpClient _httpClient;
@@ -37,13 +39,24 @@ public class GoCardlessService
             if (!TransientStatusCodes.Contains(response.StatusCode) || attempt == MaxRetries)
                 return response;
 
-            var delay = RetryBaseDelay * attempt;
+            var delay = GetRetryDelay(response, attempt);
             _logger.LogWarning("GoCardless returned {StatusCode}; retrying in {Delay} (attempt {Attempt}/{MaxRetries})",
                 response.StatusCode, delay, attempt, MaxRetries);
             await Task.Delay(delay);
         }
 
         throw new InvalidOperationException("Retry loop terminated without returning a response");
+    }
+
+    private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
+    {
+        if (response.StatusCode == HttpStatusCode.TooManyRequests
+            && response.Headers.RetryAfter?.Delta is { } retryAfter)
+        {
+            return retryAfter > MaxRetryDelay ? MaxRetryDelay : retryAfter;
+        }
+
+        return RetryBaseDelay * attempt;
     }
 
     // TODO():Change this Transactions from DAO to a Model dto

--- a/scripts/cleanup_duplicate_creditor_accounts.sql
+++ b/scripts/cleanup_duplicate_creditor_accounts.sql
@@ -1,0 +1,35 @@
+-- One-time cleanup: merge duplicate CreditorAccount rows before deploying the
+-- TransactionsRepository dedup fix.
+--
+-- The buggy code path created a NEW CreditorAccount row for every sync, keyed only by
+-- its Guid default value, so the same Iban could exist many times. This script:
+--   1. Repoints every Transaction.CreditorAccountId to the oldest CreditorAccount per Iban.
+--   2. Deletes the now-unreferenced duplicate rows.
+--
+-- Run inside a transaction so the operation is atomic. To audit first, run the SELECT
+-- queries below and review the counts before executing the UPDATE/DELETE.
+
+BEGIN TRANSACTION;
+
+-- Preview: duplicates per Iban (more than one row sharing an Iban).
+-- SELECT Iban, COUNT(*) AS Duplicates FROM CreditorAccounts GROUP BY Iban HAVING COUNT(*) > 1;
+
+-- Repoint transactions to the keeper row (MIN(Id)) per Iban.
+UPDATE t
+SET t.CreditorAccountId = keeper.Id
+FROM Transactions t
+JOIN CreditorAccounts c ON c.Id = t.CreditorAccountId
+JOIN (
+    SELECT Iban, MIN(Id) AS Id
+    FROM CreditorAccounts
+    GROUP BY Iban
+) keeper ON keeper.Iban = c.Iban
+WHERE t.CreditorAccountId <> keeper.Id;
+
+-- Delete duplicate rows that no transaction references.
+DELETE c
+FROM CreditorAccounts c
+LEFT JOIN Transactions t ON t.CreditorAccountId = c.Id
+WHERE t.Id IS NULL;
+
+COMMIT TRANSACTION;


### PR DESCRIPTION
## What

* Match incoming transactions against existing rows by transaction id and internal id before inserting
* Re-resolve planned inserts against the database to skip or update transactions already present (including across bank accounts)
* Deduplicate creditor and debtor accounts per sync so the same IBAN reuses one row
* Honor GoCardless `Retry-After` on HTTP 429 responses and retry on rate limiting
* Add an EF Core migration and DbSet so the `CreditorAccounts` table matches the model
* Add a one-time SQL cleanup script to merge legacy duplicate creditor account rows
* Cover the new behavior with unit tests

## Why

* Prevent primary-key duplicate exceptions that crashed syncs when the same transaction arrived again
* Ensure a full-payload sync is idempotent and never inserts rows that already exist
* Stop creating a new creditor account row per sync, which left many duplicate IBAN rows in the database
* Avoid failing scheduled syncs when the GoCardless API returns 429 rate-limit responses
* Keep the schema and EF model in sync so querying and future migrations work as intended
* Fix existing duplicate rows in production before the dedup logic ships
* Guard the fixes against regressions