### PR TITLE
fix: tolerate refresh token reuse within a grace window to prevent random 401s

### DIFF
--- a/BankoApi.Tests/Services/TokenServiceTests.cs
+++ b/BankoApi.Tests/Services/TokenServiceTests.cs
@@ -11,10 +11,10 @@ namespace BankoApi.Tests.Services;
 
 public class TokenServiceTests
 {
-    private BankoDbContext CreateContext()
+    private BankoDbContext CreateContext(string? dbName = null)
     {
         var options = new DbContextOptionsBuilder<BankoDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
             .Options;
         return new BankoDbContext(options);
     }
@@ -28,7 +28,8 @@ public class TokenServiceTests
                 ["Jwt:Issuer"] = "TestIssuer",
                 ["Jwt:Audience"] = "TestAudience",
                 ["Jwt:AccessTokenExpirationMinutes"] = "15",
-                ["Jwt:RefreshTokenExpirationDays"] = "7"
+                ["Jwt:RefreshTokenExpirationDays"] = "7",
+                ["Jwt:RefreshReuseGraceSeconds"] = "300"
             })!
             .Build();
     }
@@ -107,6 +108,125 @@ public class TokenServiceTests
         var oldToken = ctx.RefreshTokens.FirstOrDefault(rt => rt.Token == originalRefresh);
         Assert.NotNull(oldToken);
         Assert.True(oldToken.IsUsed);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_RotationRecordsUsedAtAndReplacement()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, originalRefresh, _) = await service.GenerateTokensAsync(user);
+
+        var (_, _, newRefresh, _) = await service.RefreshTokenAsync(originalRefresh);
+
+        var oldToken = ctx.RefreshTokens.First(rt => rt.Token == originalRefresh);
+        var newToken = ctx.RefreshTokens.First(rt => rt.Token == newRefresh);
+
+        Assert.True(oldToken.IsUsed);
+        Assert.NotNull(oldToken.UsedAt);
+        Assert.Equal(newToken.Id, oldToken.ReplacedByTokenId);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ReplayWithinGrace_HealsSession()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, originalRefresh, _) = await service.GenerateTokensAsync(user);
+
+        await service.RefreshTokenAsync(originalRefresh);
+
+        var (userId, accessToken, refreshToken, expiresIn) = await service.RefreshTokenAsync(originalRefresh);
+
+        Assert.Equal(user.UserId, userId);
+        Assert.NotEmpty(accessToken);
+        Assert.NotEmpty(refreshToken);
+        Assert.Equal(900L, expiresIn);
+
+        var refreshedToken = await service.RefreshTokenAsync(refreshToken);
+        Assert.Equal(user.UserId, refreshedToken.userId);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ReplayAfterGrace_ThrowsAndRevokes()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, originalRefresh, _) = await service.GenerateTokensAsync(user);
+
+        await service.RefreshTokenAsync(originalRefresh);
+
+        var usedToken = ctx.RefreshTokens.First(rt => rt.Token == originalRefresh);
+        usedToken.UsedAt = DateTime.UtcNow.AddMinutes(-10);
+        ctx.SaveChanges();
+
+        await Assert.ThrowsAsync<SecurityTokenException>(() =>
+            service.RefreshTokenAsync(originalRefresh));
+
+        var revokedToken = ctx.RefreshTokens.First(rt => rt.Token == originalRefresh);
+        Assert.True(revokedToken.IsRevoked);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ReplayWhenChainEndUsed_ReturnsCurrentToken()
+    {
+        using var ctx = CreateContext();
+        var config = CreateConfig();
+        var service = new TokenService(config, ctx);
+        var user = CreateUser(ctx);
+        var (_, originalRefresh, _) = await service.GenerateTokensAsync(user);
+
+        var (_, _, secondRefresh, _) = await service.RefreshTokenAsync(originalRefresh);
+
+        var chainEnd = ctx.RefreshTokens.First(rt => rt.Token == secondRefresh);
+        chainEnd.IsUsed = true;
+        chainEnd.UsedAt = DateTime.UtcNow;
+        ctx.SaveChanges();
+
+        var (userId, accessToken, refreshToken, _) = await service.RefreshTokenAsync(originalRefresh);
+
+        Assert.Equal(user.UserId, userId);
+        Assert.NotEmpty(accessToken);
+        Assert.Equal(secondRefresh, refreshToken);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ConcurrentRefreshes_DoNotKillSession()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        string originalRefresh;
+        Guid userId;
+
+        using (var setupCtx = CreateContext(dbName))
+        {
+            var setupService = new TokenService(CreateConfig(), setupCtx);
+            var user = CreateUser(setupCtx);
+            userId = user.UserId;
+            var (_, refresh, _) = await setupService.GenerateTokensAsync(user);
+            originalRefresh = refresh;
+        }
+
+        using var ctxA = CreateContext(dbName);
+        using var ctxB = CreateContext(dbName);
+        var serviceA = new TokenService(CreateConfig(), ctxA);
+        var serviceB = new TokenService(CreateConfig(), ctxB);
+
+        var taskA = serviceA.RefreshTokenAsync(originalRefresh);
+        var taskB = serviceB.RefreshTokenAsync(originalRefresh);
+        var results = await Task.WhenAll(taskA, taskB);
+
+        Assert.Equal(userId, results[0].userId);
+        Assert.Equal(userId, results[1].userId);
+        Assert.NotEmpty(results[0].accessToken);
+        Assert.NotEmpty(results[1].accessToken);
+        Assert.NotEmpty(results[0].refreshToken);
+        Assert.NotEmpty(results[1].refreshToken);
     }
 
     [Fact]

--- a/BankoApi/Data/BankoDbContext.cs
+++ b/BankoApi/Data/BankoDbContext.cs
@@ -91,6 +91,8 @@ public class BankoDbContext : DbContext
         {
             entity.HasIndex(rt => rt.Token).IsUnique();
 
+            entity.HasIndex(rt => rt.ReplacedByTokenId);
+
             entity.Property(rt => rt.RowVersion).IsRowVersion();
 
             entity.HasOne(rt => rt.User)

--- a/BankoApi/Data/Dao/RefreshToken.cs
+++ b/BankoApi/Data/Dao/RefreshToken.cs
@@ -16,6 +16,10 @@ public class RefreshToken
 
     [Required] public bool IsUsed { get; set; }
 
+    public DateTime? UsedAt { get; set; }
+
+    public Guid? ReplacedByTokenId { get; set; }
+
     [Required] public bool IsRevoked { get; set; }
 
     [Timestamp]

--- a/BankoApi/Migrations/20260807113909_RefreshTokenReuseGrace.Designer.cs
+++ b/BankoApi/Migrations/20260807113909_RefreshTokenReuseGrace.Designer.cs
@@ -4,6 +4,7 @@ using BankoApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BankoApi.Migrations
 {
     [DbContext(typeof(BankoDbContext))]
-    partial class BankoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807113909_RefreshTokenReuseGrace")]
+    partial class RefreshTokenReuseGrace
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BankoApi/Migrations/20260807113909_RefreshTokenReuseGrace.cs
+++ b/BankoApi/Migrations/20260807113909_RefreshTokenReuseGrace.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefreshTokenReuseGrace : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ReplacedByTokenId",
+                table: "RefreshTokens",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UsedAt",
+                table: "RefreshTokens",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_ReplacedByTokenId",
+                table: "RefreshTokens",
+                column: "ReplacedByTokenId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_RefreshTokens_ReplacedByTokenId",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "ReplacedByTokenId",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "UsedAt",
+                table: "RefreshTokens");
+        }
+    }
+}

--- a/BankoApi/Services/TokenService.cs
+++ b/BankoApi/Services/TokenService.cs
@@ -21,7 +21,15 @@ public class TokenService
         _context = context;
     }
 
+    private const int MaxReuseChainDepth = 5;
+
     public virtual async Task<(string accessToken, string refreshToken, long expiresIn)> GenerateTokensAsync(User user)
+    {
+        var (accessToken, refreshToken, expiresIn, _) = await CreateTokenPairAsync(user);
+        return (accessToken, refreshToken, expiresIn);
+    }
+
+    private async Task<(string accessToken, string refreshToken, long expiresIn, RefreshToken refreshTokenEntity)> CreateTokenPairAsync(User user)
     {
         var accessToken = GenerateAccessToken(user);
         var refreshToken = GenerateRefreshToken();
@@ -42,7 +50,7 @@ public class TokenService
         _context.RefreshTokens.Add(refreshTokenEntity);
         await _context.SaveChangesAsync();
 
-        return (accessToken, refreshToken, expiresIn);
+        return (accessToken, refreshToken, expiresIn, refreshTokenEntity);
     }
 
     public async Task<(Guid userId, string accessToken, string refreshToken, long expiresIn)> RefreshTokenAsync(string oldRefreshToken)
@@ -57,19 +65,98 @@ public class TokenService
         if (storedToken.IsRevoked)
             throw new SecurityTokenException("Refresh token is revoked");
 
-        if (storedToken.IsUsed)
-        {
-            RevokeSingleToken(storedToken);
-            throw new SecurityTokenException("Refresh token is already used — possible token reuse detected");
-        }
-
         if (storedToken.ExpiresAt < DateTime.UtcNow)
             throw new SecurityTokenException("Refresh token has expired");
 
-        return await ExecuteRefreshTransactionAsync(storedToken);
+        if (storedToken.IsUsed)
+            return await HandleUsedTokenAsync(storedToken);
+
+        try
+        {
+            return await RotateRefreshTokenAsync(storedToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            var refreshed = await _context.RefreshTokens
+                .Include(rt => rt.User)
+                .FirstOrDefaultAsync(rt => rt.Token == oldRefreshToken);
+
+            if (refreshed == null || !refreshed.IsUsed)
+                throw new SecurityTokenException("Refresh token could not be rotated");
+
+            return await HandleUsedTokenAsync(refreshed);
+        }
     }
 
-    private async Task<(Guid userId, string accessToken, string refreshToken, long expiresIn)> ExecuteRefreshTransactionAsync(RefreshToken storedToken)
+    private async Task<(Guid userId, string accessToken, string refreshToken, long expiresIn)> HandleUsedTokenAsync(RefreshToken usedToken)
+    {
+        if (!IsWithinReuseGrace(usedToken))
+        {
+            RevokeSingleToken(usedToken);
+            throw new SecurityTokenException("Refresh token is already used — possible token reuse detected");
+        }
+
+        try
+        {
+            var newest = await ResolveNewestTokenAsync(usedToken);
+
+            if (newest == null || newest.IsRevoked || newest.ExpiresAt < DateTime.UtcNow)
+            {
+                RevokeSingleToken(usedToken);
+                throw new SecurityTokenException("Refresh token reuse detected outside a valid token chain");
+            }
+
+            if (newest.IsUsed && newest.Id == usedToken.Id)
+            {
+                RevokeSingleToken(usedToken);
+                throw new SecurityTokenException("Refresh token reuse detected without a replacement token");
+            }
+
+            if (newest.IsUsed)
+            {
+                // Another request already rotated the chain end; hand back the current valid pair.
+                var accessToken = GenerateAccessToken(newest.User);
+                return (newest.UserId, accessToken, newest.Token, GetAccessTokenExpirationMinutes() * 60L);
+            }
+
+            return await RotateRefreshTokenAsync(newest);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            var reResolved = await ResolveNewestTokenAsync(usedToken);
+            if (reResolved == null || reResolved.IsUsed || reResolved.IsRevoked || reResolved.ExpiresAt < DateTime.UtcNow)
+                throw new SecurityTokenException("Refresh token reuse detected");
+
+            var accessToken = GenerateAccessToken(reResolved.User);
+            return (reResolved.UserId, accessToken, reResolved.Token, GetAccessTokenExpirationMinutes() * 60L);
+        }
+    }
+
+    private bool IsWithinReuseGrace(RefreshToken usedToken)
+    {
+        if (usedToken.UsedAt == null) return false;
+        return DateTime.UtcNow - usedToken.UsedAt.Value <= TimeSpan.FromSeconds(GetRefreshReuseGraceSeconds());
+    }
+
+    private async Task<RefreshToken?> ResolveNewestTokenAsync(RefreshToken token)
+    {
+        var current = token;
+        for (var hop = 0; hop < MaxReuseChainDepth; hop++)
+        {
+            if (current.ReplacedByTokenId == null) return current;
+
+            var next = await _context.RefreshTokens
+                .Include(rt => rt.User)
+                .FirstOrDefaultAsync(rt => rt.Id == current.ReplacedByTokenId);
+
+            if (next == null) return current;
+            current = next;
+        }
+
+        return current;
+    }
+
+    private async Task<(Guid userId, string accessToken, string refreshToken, long expiresIn)> RotateRefreshTokenAsync(RefreshToken storedToken)
     {
         var executionStrategy = _context.Database.CreateExecutionStrategy();
         return await executionStrategy.ExecuteAsync(async () =>
@@ -77,12 +164,19 @@ public class TokenService
             await using var transaction = await TryBeginTransactionAsync();
 
             storedToken.IsUsed = true;
+            storedToken.UsedAt = DateTime.UtcNow;
             _context.RefreshTokens.Update(storedToken);
             await _context.SaveChangesAsync();
 
             try
             {
-                var (accessToken, newRefreshToken, expiresIn) = await GenerateTokensAsync(storedToken.User);
+                var (accessToken, newRefreshToken, expiresIn, newRefreshTokenEntity) =
+                    await CreateTokenPairAsync(storedToken.User);
+
+                storedToken.ReplacedByTokenId = newRefreshTokenEntity.Id;
+                _context.RefreshTokens.Update(storedToken);
+                await _context.SaveChangesAsync();
+
                 if (transaction != null) await transaction.CommitAsync();
                 return (storedToken.UserId, accessToken, newRefreshToken, expiresIn);
             }
@@ -176,6 +270,13 @@ public class TokenService
         return int.TryParse(_configuration["Jwt:RefreshTokenExpirationDays"], out var days)
             ? days
             : 7;
+    }
+
+    private int GetRefreshReuseGraceSeconds()
+    {
+        return int.TryParse(_configuration["Jwt:RefreshReuseGraceSeconds"], out var seconds)
+            ? seconds
+            : 300;
     }
 
     private void RevokeSingleToken(RefreshToken token)

--- a/BankoApi/appsettings.json
+++ b/BankoApi/appsettings.json
@@ -20,6 +20,7 @@
     "Issuer": "BankoApi",
     "Audience": "BankoMobile",
     "AccessTokenExpirationMinutes": 15,
-    "RefreshTokenExpirationDays": 30
+    "RefreshTokenExpirationDays": 30,
+    "RefreshReuseGraceSeconds": 300
   }
 }


### PR DESCRIPTION
## What

* Tolerate reuse of a just-rotated refresh token within a configurable grace window instead of failing with 401.
* Track each refresh token's replacement and use time so a replay can be resolved to the current valid token.
* Recover gracefully from refresh-token rotation races instead of surfacing 500 errors.
* Add tests covering replay within/after the grace window, rotation bookkeeping, and concurrent refreshes.

## Why

* The app can fire two refresh calls with the same single-use token (startup refresh + Ktor auto-refresh on a 401); the losing call previously got a 401 that cleared the session and left the user stuck in a 401 loop on every operation.
* Linking tokens and recording use time lets the backend heal innocent replay races while still rejecting genuine token theft after the grace window.
* Rotation races under parallel requests previously produced server errors instead of a usable session.
* The new behavior is verified to be safe and backwards-compatible.