### PR TITLE
fix: stop resurrecting soft-deleted transactions on refetch

### DIFF
--- a/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
@@ -154,6 +154,43 @@ public class TransactionsRepositoryTests
     }
 
     [Fact]
+    public async Task StoreTransactions_SoftDeletedTransaction_PreservesDeletionOnRefetch()
+    {
+        using var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        var bankAccountId = Guid.NewGuid();
+        ctx.Transactions.Add(new Transaction
+        {
+            Id = "existing-tx",
+            UserId = userId,
+            BankAccountId = bankAccountId,
+            BookingDate = DateTime.UtcNow,
+            ValueDate = DateTime.UtcNow,
+            Amount = "50.00",
+            Currency = "EUR",
+            RemittanceInformationUnstructured = "Existing",
+            RemittanceInformationUnstructuredArray = new List<string> { "Existing" },
+            InternalTransactionId = "internal-1",
+            isDeleted = true
+        });
+        await ctx.SaveChangesAsync();
+
+        var repo = new TransactionsRepository();
+        var transactions = CreateSampleTransactions();
+
+        await repo.StoreTransactions(ctx, userId, bankAccountId, transactions);
+        await ctx.SaveChangesAsync();
+
+        // Refetch must not resurrect a user-deleted transaction, nor insert a duplicate row.
+        Assert.Equal(2, ctx.Transactions.Count());
+        Assert.Single(ctx.Transactions, t => t.InternalTransactionId == "internal-1");
+        var updated = ctx.Transactions.Single(t => t.InternalTransactionId == "internal-1");
+        Assert.Equal("existing-tx", updated.Id);
+        Assert.Equal("100.00", updated.Amount);
+        Assert.True(updated.isDeleted);
+    }
+
+    [Fact]
     public async Task StoreTransactions_EmptyTransactionId_GeneratesNewGuid()
     {
         using var ctx = CreateContext();

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -198,7 +198,6 @@ public class TransactionsRepository
         existingTransaction.CreditorName = newTransaction.CreditorName;
         existingTransaction.DebtorName = newTransaction.DebtorName;
         existingTransaction.RemittanceInformationStructuredArray = newTransaction.RemittanceInformationStructuredArray;
-        existingTransaction.isDeleted = false;
 
         if (newTransaction.DebtorAccount != null)
         {


### PR DESCRIPTION
## What

* Stop resetting `isDeleted` when a refetched transaction matches an existing row

## Why

* Every transaction fetch was silently un-deleting any transaction the user had soft-deleted, so deleted transactions (e.g. GoCardless duplicates without a transactionId) reappeared in the app on every sync
