### PR TITLE
chore: harden and document soft-delete refetch invariant

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -98,6 +98,17 @@ This file gives an AI agent a quick overview of where the Banko project code liv
 
 ---
 
+## Known Invariants
+
+### Transaction soft-delete must survive refetches
+
+* `TransactionsRepository.UpdateTransactionData` must never modify `isDeleted`.
+* GoCardless sometimes returns the same transaction twice (once with `transactionId`, once without, with a different `internalTransactionId`). Users resolve these duplicates by soft-deleting them in the app.
+* A refetch that matches an existing transaction must preserve the user's deletion. Resetting `isDeleted = false` on the update path resurrects deleted duplicates on the next sync.
+* Guarded by the regression test `StoreTransactions_SoftDeletedTransaction_PreservesDeletionOnRefetch` and the `isDeleted`-preservation assertions in the transactionId and outside-window match tests.
+
+---
+
 ## Pull Request Format
 
 When creating a Pull Request description, always use the following structure:

--- a/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
+++ b/BankoApi.Tests/Repository/TransactionsRepositoryTests.cs
@@ -301,7 +301,8 @@ public class TransactionsRepositoryTests
         string internalTransactionId,
         DateTime bookingDate,
         CreditorAccountDao? creditorAccount = null,
-        DebtorAccountDao? debtorAccount = null)
+        DebtorAccountDao? debtorAccount = null,
+        bool isDeleted = false)
     {
         return new Transaction
         {
@@ -317,7 +318,7 @@ public class TransactionsRepositoryTests
             InternalTransactionId = internalTransactionId,
             CreditorAccount = creditorAccount,
             DebtorAccount = debtorAccount,
-            isDeleted = false
+            isDeleted = isDeleted
         };
     }
 
@@ -560,7 +561,7 @@ public class TransactionsRepositoryTests
         var bankAccountId = Guid.NewGuid();
         ctx.Transactions.Add(CreateSeedTransaction(
             userId, bankAccountId, "tx-9", "",
-            DateTime.Parse("2024-01-15")));
+            DateTime.Parse("2024-01-15"), isDeleted: true));
         await ctx.SaveChangesAsync();
 
         var repo = new TransactionsRepository();
@@ -580,6 +581,7 @@ public class TransactionsRepositoryTests
 
         var stored = Assert.Single(ctx.Transactions);
         Assert.Equal("200.00", stored.Amount);
+        Assert.True(stored.isDeleted);
     }
 
     [Fact]
@@ -621,7 +623,7 @@ public class TransactionsRepositoryTests
         var bankAccountId = Guid.NewGuid();
         ctx.Transactions.Add(CreateSeedTransaction(
             userId, bankAccountId, "tx-old", "",
-            DateTime.Parse("2020-01-01")));
+            DateTime.Parse("2020-01-01"), isDeleted: true));
         await ctx.SaveChangesAsync();
 
         var repo = new TransactionsRepository();
@@ -642,6 +644,7 @@ public class TransactionsRepositoryTests
         var stored = Assert.Single(ctx.Transactions);
         Assert.Equal("200.00", stored.Amount);
         Assert.Equal("internal-new", stored.InternalTransactionId);
+        Assert.True(stored.isDeleted);
     }
 
     [Fact]

--- a/BankoApi/Repository/TransactionsRepository.cs
+++ b/BankoApi/Repository/TransactionsRepository.cs
@@ -199,6 +199,9 @@ public class TransactionsRepository
         existingTransaction.DebtorName = newTransaction.DebtorName;
         existingTransaction.RemittanceInformationStructuredArray = newTransaction.RemittanceInformationStructuredArray;
 
+        // Deliberately do NOT modify existingTransaction.isDeleted here: a refetch matching a
+        // transaction the user soft-deleted must keep it deleted (GoCardless duplicate pairs).
+
         if (newTransaction.DebtorAccount != null)
         {
             existingTransaction.DebtorAccount = GetOrCreateDebtorAccount(ctx, newTransaction.DebtorAccount, debtorByIban);


### PR DESCRIPTION
## What

* Add a `## Known Invariants` section to `AGENT_INSTRUCTIONS.md` documenting that `TransactionsRepository.UpdateTransactionData` must never modify `isDeleted`
* Add a code comment at the transaction update path explaining that a refetch must preserve the user soft-delete
* Extend the transactionId and outside-window match tests to assert `isDeleted` is preserved on refetch

## Why

* Future agents (and reviewers) need a durable record of the invariant that the refetch path must not resurrect user-deleted transactions
* The comment keeps the intent visible at the exact code location so the logic is not accidentally reverted during refactors
* The extended assertions lock the invariant across every match path (internalId, transactionId, and outside-window), not just the originally reported one
